### PR TITLE
Add npm metadata for nextclaw ncp mcp package

### DIFF
--- a/packages/ncp-packages/nextclaw-ncp-mcp/package.json
+++ b/packages/ncp-packages/nextclaw-ncp-mcp/package.json
@@ -4,6 +4,15 @@
   "private": false,
   "description": "Thin NCP adapter for exposing platform MCP tools inside NextClaw NCP runtimes.",
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Peiiii/nextclaw.git"
+  },
+  "homepage": "https://github.com/Peiiii/nextclaw/tree/master/packages/ncp-packages/nextclaw-ncp-mcp",
+  "bugs": {
+    "url": "https://github.com/Peiiii/nextclaw/issues"
+  },
   "exports": {
     ".": {
       "development": "./src/index.ts",


### PR DESCRIPTION
## Summary
- add npm `repository`, `homepage`, and `bugs` metadata for `@nextclaw/ncp-mcp`
- add the package license field to match the repo license and sibling published packages

## Why
The currently published `@nextclaw/ncp-mcp@0.1.107` package only returns `name` and `version` for standard npm metadata lookups:

```sh
npm view @nextclaw/ncp-mcp@0.1.107 name version homepage repository bugs --json
```

That makes the npm package page less useful for users who want to find the source package path or report issues.

## Verification
```sh
npm view @nextclaw/ncp-mcp@0.1.107 name version homepage repository bugs --json
node -e "const pkg=require('./packages/ncp-packages/nextclaw-ncp-mcp/package.json'); for (const k of ['homepage','repository','bugs','license']) { if (!pkg[k]) throw new Error(k+' missing'); } if (!String(pkg.homepage).includes('github.com/Peiiii/nextclaw/tree/master/packages/ncp-packages/nextclaw-ncp-mcp')) throw new Error('homepage mismatch'); if (!String(pkg.repository.url).includes('github.com/Peiiii/nextclaw.git')) throw new Error('repository mismatch'); if (!String(pkg.bugs.url).endsWith('/issues')) throw new Error('bugs mismatch'); console.log('metadata smoke ok');"
npm pack --dry-run --ignore-scripts ./packages/ncp-packages/nextclaw-ncp-mcp
git diff --check
```

`npm pack --dry-run --ignore-scripts` was used to validate package metadata without running build hooks.
