### PR TITLE
fix(chat): resolve NC-123 interaction issues

### DIFF
--- a/.changeset/nc-123-chat-interaction-consistency.md
+++ b/.changeset/nc-123-chat-interaction-consistency.md
@@ -1,0 +1,9 @@
+---
+"@nextclaw/ncp": patch
+"@nextclaw/ncp-toolkit": patch
+"@nextclaw/ncp-react": patch
+"@nextclaw/agent-chat-ui": patch
+"@nextclaw/ui": patch
+---
+
+修复聊天中的会话模型恢复、重试错误提示、技能选择和折叠会话列表交互，并为 `/`、`@` 选择项补充类型图标。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 ## 协作与 Git
 
 - 除非用户明确要求，禁止擅自 `git commit`、`git push`、创建 PR 或执行破坏性 git 操作。
+- 除非用户明确要求重启，或已提前告知重启影响并获得用户知情同意，禁止擅自重启 NextClaw 宿主、服务、桌面应用或当前运行实例；优先使用热更新、页面刷新或隔离进程验证。
 - 工作区可能已有用户改动。不得 revert、覆盖或格式化无关改动；若改动文件已被用户触达，先读懂现状再小心合并。
 - 用户要求提交或等价表达时，提交前必须先使用 `nextclaw-release-notes-automation` 与 `nextclaw-iteration-log-governance` 完成 `.changeset`、`docs/logs`、NPM 发布记录适用性判断和必要更新，再 stage/commit。
 - 执行提交/推送/建分支/建 PR 成功后，最终回复必须按 Codex app 要求输出对应 git directive。

--- a/docs/designs/2026-07-15-chat-interaction-consistency.design.md
+++ b/docs/designs/2026-07-15-chat-interaction-consistency.design.md
@@ -1,0 +1,66 @@
+# 聊天交互一致性设计
+
+## 背景
+
+NC-123 集中暴露了聊天主界面中的多处一致性问题：会话切换后模型偏好未恢复、重试时旧错误仍停留、`/` 与 `@` 选择项缺少类型图标、折叠侧栏的会话弹层缺少分组层级、技能面板高度跳变且内建技能不易发现。后续补充明确了分组语义：时间模式保持轻量静态标题，项目模式才支持逐组展开和收起。
+
+## 现状依据
+
+- 会话模型与思考等级已经有统一 resolver，但输入组件仍保留并行 fallback，切换会话时没有以目标会话 metadata 重新同步输入状态。
+- NCP 会话状态 manager 持有错误事实，但发送新请求前没有清理旧错误的公共 mutation。
+- 共享输入表面的 item contract 没有图标语义，宿主只能提供纯文字条目。
+- 展开侧栏已经复用 `groupSessionsByDate`，折叠标题弹层此前只渲染扁平列表。
+- 技能数据已经按 NextClaw、全局、内建三个来源分组，但技能选择器只顺序展示分组，没有直接来源筛选。
+- 现有运行实例属于用户工作现场，功能验收不能以擅自重启换取便利。
+
+## 核心判断
+
+本轮应扩展现有 owner，而不是新增平行状态或第二套列表：会话偏好继续由输入状态 owner 与既有 resolver 协作；错误继续由 NCP manager 管理；图标语义进入共享输入 item contract；会话分组继续复用同一个分组函数；技能来源继续复用既有 group 数据。
+
+## 推荐方案
+
+- 会话切换时先保留当前选择，等目标 session metadata 到达后再一次性恢复目标模型与思考等级，避免异步空窗把用户选择重置为默认值。
+- NCP runtime 在有效发送开始前调用 manager 的 `clearError`，让旧错误在重试动作发生时立即消失。
+- 为输入表面 item 增加 `command`、`panel-app`、`skill` 三种语义图标，并由共享菜单统一渲染。
+- 折叠会话弹层复用侧边栏的“时间 / 项目”模式。时间模式使用无底色、无边框的静态小标题；项目模式使用 Folder、数量和 Chevron，并复用既有项目折叠状态。
+- 技能选择器使用固定的自适应高度，并在搜索框下提供全部、NextClaw、全局、内建来源筛选。
+- 在常驻协作规则中明确：未得到用户知情同意时不得重启当前 NextClaw 运行实例，优先热更新或隔离进程验收。
+
+## Owner 与数据流
+
+- `useSessionConversationInputState` 聚合输入快照；偏好动作由独立 preference actions hook 管理，并调用既有 preference resolver。
+- `NcpAgentConversationStateManager` 是错误状态唯一 owner；React runtime 只在发送边界调用其 mutation。
+- `ChatInputSurfaceItem` 持有图标语义，slash / panel-app plugin 负责赋值，共享菜单负责展示。
+- `groupSessionsByDate` 与 `groupSessionsByProject` 继续生成唯一分组事实；标题切换器复用 session list store 的模式、置顶与项目折叠状态，不建立局部平行状态。
+- `ChatInputBarSkillPicker` 只持有搜索、来源筛选和键盘活动项等局部 UI 状态，不复制技能来源数据。
+
+## 目录组织
+
+- 会话偏好动作留在 conversation hooks，与输入状态 owner 同根。
+- 输入图标合同和渲染留在 `nextclaw-agent-chat-ui` 的 input-surface owner。
+- 折叠分组交互留在 session header title switcher，不改变展开侧栏结构。
+- 新增测试使用按组件角色命名的独立文件，避免继续扩张已接近预算的综合测试文件。
+
+## 兼容与迁移
+
+不需要数据迁移。所有新增字段均由现有宿主构建器提供；会话 metadata 缺失时继续保留当前选择，待数据到达后再恢复。分组默认展开，因此不会让既有用户首次打开时丢失会话内容。
+
+## 验收标准
+
+- 在同一 UI 实例内从 DeepSeek 会话切到 MiniMax 会话，模型按钮恢复目标会话偏好。
+- manager 已有错误时发送新请求，错误立即清空且请求继续发出。
+- `/` 与 `@` 构建出的 command、panel app、skill 条目带对应图标语义，共享菜单渲染对应图标。
+- 折叠会话弹层可切换时间与项目模式；时间分组标题简约且不可折叠，项目分组点击 Chevron 可折叠和展开。
+- 技能面板在有结果与无结果时高度不跳变，可直接筛选内建技能。
+- 相关包测试、`tsc`、ESLint、治理检查、可维护性 guard 与隔离浏览器冒烟通过。
+
+## 非目标
+
+- 不重做完整聊天信息架构。
+- 不新增会话分组持久化偏好。
+- 不更改技能来源优先级或安装机制。
+- 不重启、发布或部署用户当前运行的 NextClaw 实例。
+
+## 后续实现顺序
+
+先闭合状态 owner 与共享合同，再完成列表和技能交互，最后执行隔离 UI 验收、治理检查和 PR 交付。

--- a/docs/logs/v0.23.5-chat-interaction-consistency/README.md
+++ b/docs/logs/v0.23.5-chat-interaction-consistency/README.md
@@ -1,0 +1,63 @@
+# v0.23.5 聊天交互一致性
+
+## 迭代完成说明
+
+本轮完成 Linear NC-123 的聊天交互修复与增强：
+
+- 根因一：输入组件同时依赖本地状态与渲染 fallback，目标会话 metadata 异步到达时没有重新以该会话偏好同步，导致模型按钮保留上一会话值。修复后由输入状态 owner 在 session key 变化和 metadata 到达两个阶段统一恢复模型与思考等级。
+- 根因二：NCP manager 的错误状态只有写入路径，没有发送前清理 mutation，重试时旧错误会继续显示。修复后在有效发送开始前由 runtime 调用 manager `clearError`。
+- 根因三：共享输入 item contract 缺少图标语义，`/` 与 `@` 的命令、Panel App、Skill 无法由统一菜单区分展示。修复后由 plugin 赋值、共享菜单统一渲染。
+- 折叠侧栏的会话切换器复用现有“时间 / 项目”模式：时间模式显示轻量静态标题，项目模式显示 Folder、数量和 Chevron，并共享既有项目折叠状态。
+- 技能选择器固定自适应高度，搜索结果变化时不再跳变，并支持直接筛选 NextClaw、全局和内建技能。
+- `AGENTS.md` 新增运行实例保护规则：没有用户知情同意不得擅自重启，优先热更新、页面刷新或隔离进程验证。
+- 稳定 owner 与数据流记录在 `docs/designs/2026-07-15-chat-interaction-consistency.design.md`。
+
+## 测试/验证/验收方式
+
+- `@nextclaw/agent-chat-ui` 定向测试：4 个文件、44 项通过。
+- `@nextclaw/ui` 定向测试：会话偏好、NCP 重试、折叠分组、输入 plugin 与会话输入共 7 个文件、26 项通过；Header 分组专项 9 项通过。
+- `@nextclaw/ncp-toolkit` conversation state manager 定向测试：19 项通过。
+- `@nextclaw/ncp`、`@nextclaw/ncp-toolkit`、`@nextclaw/ncp-react`、`@nextclaw/agent-chat-ui`、`@nextclaw/ui` 的定向 `tsc` 通过。
+- 五个相关包 package lint 均无 error；本次触达文件无 warning。未触达的历史 warning 包括 `cron-config.tsx` 复杂度、NCP reasoning flush、toolkit 既有测试文件长度与 reply consumer 参数读取。
+- `pnpm -C packages/nextclaw-ui build`：通过；构建后的生成物已用 `pnpm clean:generated` 清理，`pnpm check:generated-clean` 通过。
+- `pnpm lint:new-code:governance`：通过，保留一条 NCP toolkit 历史目录 warning；`pnpm check:governance-backlog-ratchet`：通过。
+- 隔离浏览器验收使用 `http://127.0.0.1:5176`，代理现有 `127.0.0.1:18792` 后端，未重启 5174/18792 或其它现有进程。
+- 模型恢复：同一 UI 内从 `DeepSeek/deepseek-v4-flash` 会话切到 `MiniMax/MiniMax-M3` 会话，模型按钮正确恢复为目标偏好。
+- 技能选择器：有结果和无结果时面板高度均为 `309.0625px`；来源按钮显示全部 87、NextClaw 35、全局 34、内建 18，并可筛到内建技能。
+- 折叠会话弹层：真实数据在时间模式按今天、昨天、近 7 天、更早显示轻量静态标题；切到项目模式后显示 `nextbot` 项目组、数量和 Chevron，点击后从“收起项目”变为“展开项目”，组内会话隐藏。
+- `/`、`@` 图标由共享组件测试与消费端 Vite 源码加载证明；浏览器自动化输入事件未触发实际弹层，因此不声明这一路径已完成可见手势验收。
+- 旧错误清理由 assembled React/NCP manager 测试证明；为避免影响正在运行的实例，没有人为制造真实网络故障。
+
+## 发布/部署方式
+
+本轮先提交隔离分支并创建 Ready PR；用户随后明确要求直接合并，因此继续合入远端 `master`。不执行 NPM 发布、runtime update、桌面发布、部署或 migration。现有 NextClaw 运行实例未重启，本地含未提交改动的主工作区也不自动拉取远端变更。
+
+## 用户/产品视角的验收步骤
+
+1. 打开聊天页，在两个配置了不同 preferred model 的会话间切换，确认模型按钮随目标会话变化。
+2. 让一次发送出现错误后重新发送，确认旧错误在新请求开始时消失。
+3. 在输入框使用 `/` 与 `@`，确认命令、Panel App、Skill 条目显示不同图标。
+4. 收起侧栏并打开标题处的会话切换器，确认时间模式的置顶与日期分组使用轻量静态标题；切换到项目模式后，点击项目右侧 Chevron，确认项目组可折叠和恢复。
+5. 打开技能选择器，搜索无结果后确认面板高度不跳变；点击“内建技能”确认可直接浏览内建来源。
+
+## 可维护性总结汇总
+
+- 会话偏好继续复用既有 resolver，未增加第二套 model fallback；输入组件同时净减旧 fallback 分支。
+- NCP 错误状态仍由 manager 单一 owner 管理，runtime 只调用明确 mutation。
+- 输入图标只扩展共享 item contract，宿主 plugin 不复制图标 JSX。
+- 折叠与展开侧栏继续复用同一个 session grouping owner、列表模式与项目折叠状态；时间分组不引入无必要的展开状态。
+- 技能来源筛选复用既有 groups，不复制技能 registry。
+- 已把技能面板专项验证从历史超限综合测试移到独立角色测试，避免继续扩大热点文件并消除重复用例。
+- `post-edit-maintainability-guard`：通过，检查 28 个文件，0 error、3 个历史热点 warning。
+- 代码增减报告：新增 825 行、删除 197 行、净增 628 行；非测试代码新增 553 行、删除 176 行、净增 377 行。本轮包含新的用户可见时间/项目分组、项目折叠、来源筛选和公共输入图标 contract，正增长属于功能交付；实现已复用现有 resolver、manager、group 和 plugin owner，没有引入平行链路。
+- 主观复核结论：通过，no maintainability findings。本次顺手减债包括删除输入组件的并行 fallback、移除技能选择器的 effect 状态修补、把重复面板测试移出历史热点并让该文件净减 15 行；Header 分组展示已拆到独立展示组件，使标题切换 owner 退出 500 行热点预警。
+
+## NPM 包发布记录
+
+本轮包含用户可见行为和公共 contract 变更，已新增 changeset，以下包均需 patch 且当前未发布，状态为待统一发布：
+
+- `@nextclaw/ncp@0.7.3`
+- `@nextclaw/ncp-toolkit@0.6.4`
+- `@nextclaw/ncp-react@0.5.4`
+- `@nextclaw/agent-chat-ui@0.6.5`
+- `@nextclaw/ui@0.15.5`

--- a/docs/logs/v0.23.5-chat-interaction-consistency/README.md
+++ b/docs/logs/v0.23.5-chat-interaction-consistency/README.md
@@ -21,6 +21,7 @@
 - 五个相关包 package lint 均无 error；本次触达文件无 warning。未触达的历史 warning 包括 `cron-config.tsx` 复杂度、NCP reasoning flush、toolkit 既有测试文件长度与 reply consumer 参数读取。
 - `pnpm -C packages/nextclaw-ui build`：通过；构建后的生成物已用 `pnpm clean:generated` 清理，`pnpm check:generated-clean` 通过。
 - `pnpm lint:new-code:governance`：通过，保留一条 NCP toolkit 历史目录 warning；`pnpm check:governance-backlog-ratchet`：通过。
+- 合并阻塞修复：拓扑 JSONC reader 不再把路径别名字符串 `"@/*"` 误判为块注释；回归测试与 `pnpm report:topology -- --top 50` 均通过。
 - 隔离浏览器验收使用 `http://127.0.0.1:5176`，代理现有 `127.0.0.1:18792` 后端，未重启 5174/18792 或其它现有进程。
 - 模型恢复：同一 UI 内从 `DeepSeek/deepseek-v4-flash` 会话切到 `MiniMax/MiniMax-M3` 会话，模型按钮正确恢复为目标偏好。
 - 技能选择器：有结果和无结果时面板高度均为 `309.0625px`；来源按钮显示全部 87、NextClaw 35、全局 34、内建 18，并可筛到内建技能。
@@ -48,8 +49,10 @@
 - 折叠与展开侧栏继续复用同一个 session grouping owner、列表模式与项目折叠状态；时间分组不引入无必要的展开状态。
 - 技能来源筛选复用既有 groups，不复制技能 registry。
 - 已把技能面板专项验证从历史超限综合测试移到独立角色测试，避免继续扩大热点文件并消除重复用例。
+- 拓扑治理修复只收紧整行块注释的匹配边界，并用独立回归测试锁定字符串内注释标记语义，没有引入新的解析 owner 或运行时依赖。
 - `post-edit-maintainability-guard`：通过，检查 28 个文件，0 error、3 个历史热点 warning。
 - 代码增减报告：新增 825 行、删除 197 行、净增 628 行；非测试代码新增 553 行、删除 176 行、净增 377 行。本轮包含新的用户可见时间/项目分组、项目折叠、来源筛选和公共输入图标 contract，正增长属于功能交付；实现已复用现有 resolver、manager、group 和 plugin owner，没有引入平行链路。
+- 合并阻塞补丁另检查 2 个文件，新增 37 行、删除 1 行；非测试代码新增 1 行、删除 1 行、净增 0，0 error、0 warning。
 - 主观复核结论：通过，no maintainability findings。本次顺手减债包括删除输入组件的并行 fallback、移除技能选择器的 effect 状态修补、把重复面板测试移出历史热点并让该文件净减 15 行；Header 分组展示已拆到独立展示组件，使标题切换 owner 退出 500 行热点预警。
 
 ## NPM 包发布记录

--- a/packages/ncp-packages/nextclaw-ncp-react/src/hooks/use-ncp-agent-runtime.ts
+++ b/packages/ncp-packages/nextclaw-ncp-react/src/hooks/use-ncp-agent-runtime.ts
@@ -267,6 +267,7 @@ export function useNcpAgentRuntime({
       return null;
     }
 
+    manager.clearError();
     setIsSending(true);
     if (sessionId) {
       await manager.dispatch({

--- a/packages/ncp-packages/nextclaw-ncp-toolkit/src/agent/agent-conversation-state.manager.ts
+++ b/packages/ncp-packages/nextclaw-ncp-toolkit/src/agent/agent-conversation-state.manager.ts
@@ -105,6 +105,14 @@ export class DefaultNcpAgentConversationStateManager implements NcpAgentConversa
     this.notifyListeners();
   };
 
+  clearError = (): void => {
+    const versionBeforeClear = this.stateVersion;
+    this.setError(null);
+    if (this.stateVersion !== versionBeforeClear) {
+      this.notifyListeners();
+    }
+  };
+
   hydrate = (payload: NcpAgentConversationHydrationParams): void => {
     this.messages = payload.messages.map((message: NcpMessage) => normalizeConversationMessage(message));
     this.streamingMessage = null;

--- a/packages/ncp-packages/nextclaw-ncp/src/toolkit/agent/agent-conversation-state.manager.ts
+++ b/packages/ncp-packages/nextclaw-ncp/src/toolkit/agent/agent-conversation-state.manager.ts
@@ -43,6 +43,7 @@ export type NcpAgentConversationHydrationParams = {
 export interface NcpAgentConversationStateManager extends NcpConversationStateManager {
   getSnapshot(): NcpAgentConversationSnapshot;
   reset(): void;
+  clearError(): void;
   hydrate(payload: NcpAgentConversationHydrationParams): void;
   /** Local peer sent a message (outbound); typically non-streaming. Add to messages. */
   handleMessageSent(payload: NcpMessageSentPayload): void;

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/__tests__/chat-input-bar-skill-picker.test.tsx
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/__tests__/chat-input-bar-skill-picker.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ChatInputBarSkillPicker } from '@agent-chat-ui/components/chat/ui/chat-input-bar/chat-input-bar-skill-picker';
+import type { ChatSkillPickerProps } from '@agent-chat-ui/components/chat/view-models/chat-ui.types';
+
+const createPicker = (): ChatSkillPickerProps => ({
+  title: 'Skills',
+  allGroupsLabel: 'All skills',
+  searchPlaceholder: 'Search skills',
+  loadingLabel: 'Loading skills',
+  emptyLabel: 'No skills',
+  options: [
+    { key: 'web-search', label: 'Web Search', description: 'Search the web' },
+    { key: '$builtin/summarize', label: 'Summarize', description: 'Summarize the conversation' },
+  ],
+  groups: [
+    {
+      key: 'workspace',
+      label: 'Workspace skills',
+      options: [{ key: 'web-search', label: 'Web Search', description: 'Search the web' }],
+    },
+    {
+      key: 'builtin',
+      label: 'Built-in skills',
+      options: [{
+        key: '$builtin/summarize',
+        label: 'Summarize',
+        description: 'Summarize the conversation',
+      }],
+    },
+  ],
+  selectedKeys: [],
+  onSelectedKeysChange: vi.fn(),
+});
+
+it('keeps a fixed panel height and filters directly to built-in skills', () => {
+  render(<ChatInputBarSkillPicker picker={createPicker()} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Skills' }));
+  const listbox = screen.getByRole('listbox');
+  const panelStyle = listbox.closest('[data-state="open"]')?.getAttribute('style') ?? '';
+  expect(listbox.className).toContain('flex-1');
+  expect(listbox.className).toContain('overflow-y-auto');
+  expect(listbox.className).toContain('overscroll-contain');
+  expect(panelStyle).toContain('20rem');
+  expect(panelStyle).toContain('--radix-popover-content-available-height');
+  expect(panelStyle).toContain('100vh');
+  expect(panelStyle).toContain('2rem');
+
+  fireEvent.click(screen.getByRole('button', { name: /built-in skills/i }));
+  expect(screen.getByText('Summarize')).toBeTruthy();
+  expect(screen.queryByText('Web Search')).toBeNull();
+  expect(screen.getByRole('button', { name: /built-in skills/i }).getAttribute('aria-pressed')).toBe('true');
+});

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/__tests__/chat-input-bar.test.tsx
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/__tests__/chat-input-bar.test.tsx
@@ -222,6 +222,7 @@ function SkillPickerInsertionHarness() {
         toolbar: {
           skillPicker: {
             title: 'Skills',
+            allGroupsLabel: 'All skills',
             searchPlaceholder: 'Search skills',
             loadingLabel: 'Loading skills',
             emptyLabel: 'No skills',
@@ -372,22 +373,6 @@ it('shows a selected skill inside the composer after choosing it from the skill 
 
   await waitFor(() => expect(screen.getByText('Web Search')).toBeTruthy());
   expect(screen.getByRole('textbox').querySelector('[data-composer-token-key="web-search"]')).toBeTruthy();
-});
-
-it('keeps the skill picker panel constrained to the available viewport height', async () => {
-  render(<SkillPickerInsertionHarness />);
-
-  fireEvent.click(screen.getByRole('button', { name: /skills/i }));
-
-  const listbox = await screen.findByRole('listbox');
-  expect(listbox.className).toContain('flex-1');
-  expect(listbox.className).toContain('overflow-y-auto');
-  const panelStyle = listbox.closest('[data-state="open"]')?.getAttribute('style') ?? '';
-  expect(panelStyle).toContain('24rem');
-  expect(panelStyle).toContain('--radix-popover-content-available-height');
-  expect(panelStyle).toContain('100vh');
-  expect(panelStyle).toContain('2rem');
-  expect(listbox.className).toContain('overscroll-contain');
 });
 
 it('keeps skill option text selectable without toggling the skill', async () => {

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/__tests__/chat-slash-menu.test.tsx
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/__tests__/chat-slash-menu.test.tsx
@@ -108,7 +108,6 @@ describe('ChatSlashMenu', () => {
     expect(allFilter.className).toContain('bg-gray-100');
     expect(allFilter.className).not.toContain('border-primary');
     expect(screen.getByRole('button', { name: 'Panel Apps 1' }).className).toContain('hover:bg-gray-100');
-
     const firstOption = screen.getByRole('option', { name: /Side chat/i });
     expect(firstOption.className).toContain('py-1');
     expect(firstOption.className).not.toContain('py-1.5');

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/chat-input-bar-skill-picker.tsx
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/ui/chat-input-bar/chat-input-bar-skill-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState, type KeyboardEventHandler } from 'react';
+import { useId, useMemo, useRef, useState, type KeyboardEventHandler } from 'react';
 import { BrainCircuit, Check, ExternalLink, Puzzle, Search } from 'lucide-react';
 import { useActiveItemScroll } from '@agent-chat-ui/components/chat/hooks/use-active-item-scroll';
 import {
@@ -21,7 +21,7 @@ function filterOptions(options: ChatSkillPickerOption[], query: string): ChatSki
   });
 }
 
-const SKILL_PICKER_MAX_HEIGHT = createChatPopoverAvailableHeightLimit('24rem');
+const SKILL_PICKER_HEIGHT = createChatPopoverAvailableHeightLimit('20rem');
 
 export function ChatInputBarSkillPicker(props: { picker: ChatSkillPickerProps }) {
   const { Input, Popover, PopoverContent, PopoverTrigger } = ChatUiPrimitives;
@@ -29,40 +29,44 @@ export function ChatInputBarSkillPicker(props: { picker: ChatSkillPickerProps })
   const listRef = useRef<HTMLDivElement | null>(null);
   const listId = useId();
   const [query, setQuery] = useState('');
+  const [activeGroupKey, setActiveGroupKey] = useState<string | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const selectedSet = useMemo(() => new Set(picker.selectedKeys), [picker.selectedKeys]);
   const selectedCount = picker.selectedKeys.length;
-  const isSearchActive = query.trim().length > 0;
+  const availableGroups = useMemo(
+    () => picker.groups?.filter((group) => group.options.length > 0) ?? [],
+    [picker.groups],
+  );
+  const resolvedActiveGroupKey = availableGroups.some((group) => group.key === activeGroupKey)
+    ? activeGroupKey
+    : null;
   const groupedOptions = useMemo<ChatSkillPickerOptionGroup[] | null>(() => {
-    if (isSearchActive) {
+    if (availableGroups.length === 0) {
       return null;
     }
-    const groups = picker.groups?.filter((group) => group.options.length > 0) ?? [];
-    return groups.length > 0 ? groups : null;
-  }, [isSearchActive, picker.groups]);
+    const groups = resolvedActiveGroupKey
+      ? availableGroups.filter((group) => group.key === resolvedActiveGroupKey)
+      : availableGroups;
+    return groups
+      .map((group) => ({
+        ...group,
+        options: filterOptions(group.options, query),
+      }))
+      .filter((group) => group.options.length > 0);
+  }, [availableGroups, query, resolvedActiveGroupKey]);
   const visibleOptions = useMemo(() => {
-    if (groupedOptions) {
+    if (groupedOptions !== null) {
       return groupedOptions.flatMap((group) => group.options);
     }
     return filterOptions(picker.options, query);
   }, [groupedOptions, picker.options, query]);
-
-  useEffect(() => {
-    setActiveIndex(0);
-  }, [query]);
-
-  useEffect(() => {
-    setActiveIndex((current) => {
-      if (visibleOptions.length === 0) {
-        return 0;
-      }
-      return Math.min(current, visibleOptions.length - 1);
-    });
-  }, [visibleOptions.length]);
+  const resolvedActiveIndex = visibleOptions.length === 0
+    ? 0
+    : Math.min(activeIndex, visibleOptions.length - 1);
 
   useActiveItemScroll({
     containerRef: listRef,
-    activeIndex,
+    activeIndex: resolvedActiveIndex,
     itemCount: visibleOptions.length,
     isEnabled: visibleOptions.length > 0,
     getItemSelector: (index) => `[data-skill-index="${index}"]`
@@ -83,19 +87,19 @@ export function ChatInputBarSkillPicker(props: { picker: ChatSkillPickerProps })
 
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      setActiveIndex((current) => Math.min(current + 1, visibleOptions.length - 1));
+      setActiveIndex(Math.min(resolvedActiveIndex + 1, visibleOptions.length - 1));
       return;
     }
 
     if (event.key === 'ArrowUp') {
       event.preventDefault();
-      setActiveIndex((current) => Math.max(current - 1, 0));
+      setActiveIndex(Math.max(resolvedActiveIndex - 1, 0));
       return;
     }
 
     if (event.key === 'Enter') {
       event.preventDefault();
-      const activeOption = visibleOptions[activeIndex];
+      const activeOption = visibleOptions[resolvedActiveIndex];
       if (activeOption) {
         onToggleOption(activeOption.key);
       }
@@ -126,7 +130,7 @@ export function ChatInputBarSkillPicker(props: { picker: ChatSkillPickerProps })
         side="top"
         align="start"
         className="flex w-[min(360px,calc(100vw-1rem))] flex-col overflow-hidden p-0"
-        style={{ maxHeight: SKILL_PICKER_MAX_HEIGHT }}
+        style={{ height: SKILL_PICKER_HEIGHT }}
       >
         <div className="shrink-0 space-y-2 border-b border-border px-4 py-3">
           <div className="text-sm font-semibold text-foreground">{picker.title}</div>
@@ -134,17 +138,56 @@ export function ChatInputBarSkillPicker(props: { picker: ChatSkillPickerProps })
             <Search className="pointer-events-none absolute left-3 top-2.5 h-3.5 w-3.5 text-muted-foreground/70" />
             <Input
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
               onKeyDown={onSearchKeyDown}
               placeholder={picker.searchPlaceholder}
               role="combobox"
               aria-controls={listId}
               aria-expanded="true"
               aria-autocomplete="list"
-              aria-activedescendant={visibleOptions[activeIndex] ? `${listId}-option-${activeIndex}` : undefined}
+              aria-activedescendant={visibleOptions[resolvedActiveIndex]
+                ? `${listId}-option-${resolvedActiveIndex}`
+                : undefined}
               className="h-8 rounded-lg pl-8 text-xs"
             />
           </div>
+          {availableGroups.length > 0 ? (
+            <div className="flex flex-wrap gap-1" aria-label={picker.allGroupsLabel}>
+              {[
+                { key: null, label: picker.allGroupsLabel, count: picker.options.length },
+                ...availableGroups.map((group) => ({
+                  key: group.key,
+                  label: group.label || group.key,
+                  count: group.options.length,
+                })),
+              ].map((group) => {
+                const isActive = group.key === resolvedActiveGroupKey;
+                return (
+                  <button
+                    key={group.key ?? 'all-skills'}
+                    type="button"
+                    aria-pressed={isActive}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => {
+                      setActiveGroupKey(group.key);
+                      setActiveIndex(0);
+                    }}
+                    className={`inline-flex h-6 items-center gap-1 rounded-md px-2 text-[10px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                      isActive
+                        ? 'bg-primary/10 text-primary'
+                        : 'bg-muted text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    <span>{group.label}</span>
+                    <span className="opacity-70">{group.count}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
         </div>
 
         <div
@@ -174,7 +217,7 @@ export function ChatInputBarSkillPicker(props: { picker: ChatSkillPickerProps })
                       const index = visibleIndex;
                       visibleIndex += 1;
                       const isSelected = selectedSet.has(option.key);
-                      const isActive = index === activeIndex;
+                      const isActive = index === resolvedActiveIndex;
                       return (
                         <div
                           key={option.key}

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/ui/input-surface/__tests__/chat-input-surface-menu.test.tsx
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/ui/input-surface/__tests__/chat-input-surface-menu.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { ChatInputSurfaceMenu } from '@agent-chat-ui/components/chat/ui/input-surface/chat-input-surface-menu';
+
+it('renders the semantic icon assigned to each input-surface item', () => {
+  render(
+    <ChatInputSurfaceMenu
+      isOpen
+      isLoading={false}
+      items={[
+        { key: 'command', icon: 'command', title: 'Command', subtitle: '', description: '', detailLines: [] },
+        { key: 'panel-app', icon: 'panel-app', title: 'Panel app', subtitle: '', description: '', detailLines: [] },
+        { key: 'skill', icon: 'skill', title: 'Skill', subtitle: '', description: '', detailLines: [] },
+      ]}
+      texts={{
+        loadingLabel: 'Loading',
+        sectionLabel: 'Items',
+        emptyLabel: 'No items',
+        hintLabel: 'Type',
+        itemHintLabel: 'Select',
+      }}
+      onOpenChange={vi.fn()}
+      onSelectItem={vi.fn()}
+    />,
+  );
+
+  expect(document.querySelectorAll('[data-input-surface-icon="command"]')).toHaveLength(1);
+  expect(document.querySelectorAll('[data-input-surface-icon="panel-app"]')).toHaveLength(1);
+  expect(document.querySelectorAll('[data-input-surface-icon="skill"]')).toHaveLength(1);
+});

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/ui/input-surface/chat-input-surface-menu.tsx
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/ui/input-surface/chat-input-surface-menu.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { Command, PanelsTopLeft, Puzzle } from 'lucide-react';
 import { useActiveItemScroll } from '@agent-chat-ui/components/chat/hooks/use-active-item-scroll';
 import { useElementWidth } from '@agent-chat-ui/components/chat/hooks/use-element-width';
 import {
@@ -8,6 +9,7 @@ import {
 import type {
   ChatInputSurfaceFilterOption,
   ChatInputSurfaceItem,
+  ChatInputSurfaceItemIcon,
   ChatInputSurfaceMenuProps,
 } from '@agent-chat-ui/lib/input-surface';
 
@@ -35,6 +37,19 @@ function itemMatchesFilter(item: ChatInputSurfaceItem, filter: ChatInputSurfaceF
     return true;
   }
   return Boolean(item.sectionKey && filter.sectionKeys.includes(item.sectionKey));
+}
+
+function InputSurfaceItemIcon({ icon }: { icon: ChatInputSurfaceItemIcon }) {
+  const Icon = icon === 'command' ? Command : icon === 'panel-app' ? PanelsTopLeft : Puzzle;
+  return (
+    <span
+      aria-hidden="true"
+      data-input-surface-icon={icon}
+      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-500"
+    >
+      <Icon className="h-3.5 w-3.5" />
+    </span>
+  );
 }
 
 export const ChatInputSurfaceMenu = forwardRef<ChatInputSurfaceMenuHandle, ChatInputSurfaceMenuProps>(
@@ -235,7 +250,7 @@ function ChatInputSurfaceMenu(props, ref) {
                   ) : (
                     <div>
                       {visibleItems.map((item, index) => {
-                        const { key, sectionKey, sectionLabel, title, subtitle } = item;
+                        const { icon, key, sectionKey, sectionLabel, title, subtitle } = item;
                         const isActive = index === activeIndexInRange;
                         const previousItem = visibleItems[index - 1];
                         const shouldShowSection =
@@ -275,6 +290,7 @@ function ChatInputSurfaceMenu(props, ref) {
                                 isActive ? 'bg-gray-100 text-gray-900' : 'text-gray-700 hover:bg-gray-100'
                               }`}
                             >
+                              {icon ? <InputSurfaceItemIcon icon={icon} /> : null}
                               <span className="truncate text-xs font-medium">{title}</span>
                               <span className="truncate text-xs text-gray-500">{subtitle}</span>
                             </button>

--- a/packages/nextclaw-agent-chat-ui/src/components/chat/view-models/chat-ui.types.ts
+++ b/packages/nextclaw-agent-chat-ui/src/components/chat/view-models/chat-ui.types.ts
@@ -126,6 +126,7 @@ export type ChatSkillPickerOptionGroup = {
 
 export type ChatSkillPickerProps = {
   title: string;
+  allGroupsLabel: string;
   searchPlaceholder: string;
   emptyLabel: string;
   loadingLabel: string;

--- a/packages/nextclaw-agent-chat-ui/src/lib/input-surface/index.ts
+++ b/packages/nextclaw-agent-chat-ui/src/lib/input-surface/index.ts
@@ -7,6 +7,7 @@ export type {
   ChatInputSurfaceConfig,
   ChatInputSurfaceFilterOption,
   ChatInputSurfaceItem,
+  ChatInputSurfaceItemIcon,
   ChatInputSurfaceMenuProps,
   ChatInputSurfaceMenuTexts,
   ChatInputSurfacePanel,

--- a/packages/nextclaw-agent-chat-ui/src/lib/input-surface/input-surface.types.ts
+++ b/packages/nextclaw-agent-chat-ui/src/lib/input-surface/input-surface.types.ts
@@ -28,8 +28,11 @@ export type ChatInputSurfaceMenuTexts = {
   itemHintLabel: string;
 };
 
+export type ChatInputSurfaceItemIcon = 'command' | 'panel-app' | 'skill';
+
 export type ChatInputSurfaceItem = {
   key: string;
+  icon?: ChatInputSurfaceItemIcon;
   title: string;
   subtitle: string;
   description: string;

--- a/packages/nextclaw-ui/src/features/chat/components/conversation/__tests__/chat-conversation-header-section.test.tsx
+++ b/packages/nextclaw-ui/src/features/chat/components/conversation/__tests__/chat-conversation-header-section.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { PersistStorage, StorageValue } from "zustand/middleware";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   deleteSession: vi.fn(),
   toggleWorkspacePanel: vi.fn(),
   selectSession: vi.fn(),
+  setListMode: vi.fn(),
+  toggleProjectCollapsed: vi.fn(),
   sessionItems: [] as NcpSessionListItemView[],
   isSessionListLoading: false,
 }));
@@ -27,6 +29,8 @@ vi.mock("@/features/chat/components/providers/chat-presenter.provider", () => ({
     },
     chatSessionListManager: {
       selectSession: mocks.selectSession,
+      setListMode: mocks.setListMode,
+      toggleProjectCollapsed: mocks.toggleProjectCollapsed,
     },
   }),
 }));
@@ -120,6 +124,8 @@ describe("ChatConversationHeaderSection", () => {
     mocks.deleteSession.mockReset();
     mocks.toggleWorkspacePanel.mockReset();
     mocks.selectSession.mockReset();
+    mocks.setListMode.mockReset();
+    mocks.toggleProjectCollapsed.mockReset();
     mocks.isSessionListLoading = false;
     viewportLayoutManager.resetForTests();
     useChatSessionListStore.persist.setOptions({
@@ -131,9 +137,24 @@ describe("ChatConversationHeaderSection", () => {
     useChatSessionListStore.setState({
       snapshot: {
         ...useChatSessionListStore.getState().snapshot,
+        collapsedProjectRoots: [],
+        listMode: "time-first",
+        pinnedProjectRoots: [],
+        pinnedSessionKeys: [],
         selectedAgentId: "main",
         selectedSessionKey: "parent-session-1",
       },
+    });
+    mocks.setListMode.mockImplementation((listMode) => {
+      useChatSessionListStore.getState().setSnapshot({ listMode });
+    });
+    mocks.toggleProjectCollapsed.mockImplementation((projectRoot) => {
+      const { collapsedProjectRoots } = useChatSessionListStore.getState().snapshot;
+      useChatSessionListStore.getState().setSnapshot({
+        collapsedProjectRoots: collapsedProjectRoots.includes(projectRoot)
+          ? collapsedProjectRoots.filter((root) => root !== projectRoot)
+          : [...collapsedProjectRoots, projectRoot],
+      });
     });
     useChatThreadStore.setState({
       snapshot: {
@@ -227,6 +248,68 @@ describe("ChatConversationHeaderSection", () => {
     await user.click(screen.getByRole("button", { name: /Background Task/ }));
 
     expect(mocks.selectSession).toHaveBeenCalledWith("session:ncp-2");
+  });
+
+  it("uses lightweight static groups for pinned and activity dates", async () => {
+    const user = userEvent.setup();
+    viewportLayoutManager.setSidebarCollapsed(true);
+    useChatSessionListStore.setState({
+      snapshot: {
+        ...useChatSessionListStore.getState().snapshot,
+        pinnedSessionKeys: ["session:ncp-2"],
+      },
+    });
+
+    renderHeaderSection();
+    await user.click(screen.getByRole("button", { name: /Switch session/ }));
+
+    const pinnedGroup = screen.getByRole("region", { name: "Pinned" });
+    const pinnedTitle = within(pinnedGroup).getByText("Pinned");
+    expect(pinnedTitle.className).toContain("uppercase");
+    expect(pinnedTitle.className).not.toContain("bg-muted");
+    expect(within(pinnedGroup).queryByRole("button", { name: "Pinned" })).toBeNull();
+    expect(within(pinnedGroup).getByText("Background Task")).toBeTruthy();
+    expect(
+      within(screen.getByRole("region", { name: "Older" })).getByText("Parent Task"),
+    ).toBeTruthy();
+  });
+
+  it("switches to collapsible project groups inside the header popover", async () => {
+    const user = userEvent.setup();
+    viewportLayoutManager.setSidebarCollapsed(true);
+    mocks.sessionItems = [
+      createSessionListItem({
+        key: "parent-session-1",
+        label: "Parent Task",
+        projectName: "Alpha",
+        projectRoot: "/workspace/alpha",
+      }),
+      createSessionListItem({
+        key: "session:ncp-2",
+        label: "Background Task",
+        projectName: "Beta",
+        projectRoot: "/workspace/beta",
+      }),
+    ];
+
+    renderHeaderSection();
+    await user.click(screen.getByRole("button", { name: /Switch session/ }));
+    await user.click(screen.getByRole("button", { name: "Project" }));
+
+    expect(mocks.setListMode).toHaveBeenCalledWith("project-first");
+    const alphaGroup = screen.getByRole("region", { name: "Alpha" });
+    const alphaToggle = within(alphaGroup).getByRole("button", {
+      name: "Collapse project · Alpha",
+    });
+    expect(alphaToggle.getAttribute("aria-expanded")).toBe("true");
+    expect(alphaToggle.className).not.toContain("bg-muted");
+    expect(within(alphaGroup).getByText("Parent Task")).toBeTruthy();
+
+    await user.click(alphaToggle);
+    expect(mocks.toggleProjectCollapsed).toHaveBeenCalledWith("/workspace/alpha");
+    expect(
+      within(screen.getByRole("region", { name: "Alpha" })).queryByText("Parent Task"),
+    ).toBeNull();
   });
 
   it("keeps the desktop title plain while the sidebar is expanded", () => {

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/components/__tests__/session-conversation-area.test.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/components/__tests__/session-conversation-area.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => {
     removeAttachment: vi.fn(),
     setSelectedModel: vi.fn(),
     setSelectedThinkingLevel: vi.fn(),
+    syncSessionPreferences: vi.fn(),
     setPendingSessionType: vi.fn(),
     setPendingProjectRoot: vi.fn(),
     setSelectedSkills: vi.fn(),

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/components/__tests__/session-conversation-input.streaming.test.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/components/__tests__/session-conversation-input.streaming.test.tsx
@@ -145,6 +145,7 @@ function StreamingSessionConversationInputHarness({
     setSelectedModel: vi.fn(),
     setSelectedSkills: vi.fn(),
     setSelectedThinkingLevel: vi.fn(),
+    syncSessionPreferences: vi.fn(),
     setSendError: vi.fn(),
     syncComposer: vi.fn(),
     update: (patch: SessionConversationInputPatch) => {

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/components/session-conversation-area.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/components/session-conversation-area.tsx
@@ -188,6 +188,28 @@ export function SessionConversationArea(props: SessionConversationAreaProps) {
     inputSnapshot,
     setPendingSessionType: inputActions.setPendingSessionType,
   });
+  useEffect(() => {
+    inputActions.syncSessionPreferences({
+      defaultModel: inputQuery.defaultModel,
+      fallbackPreferredModel: inputQuery.fallbackPreferredModel,
+      fallbackPreferredThinking: inputQuery.fallbackPreferredThinking,
+      modelOptions: inputQuery.modelOptions,
+      selectedSessionExists: Boolean(inputQuery.selectedSession),
+      selectedSessionKey: inputQuery.selectedSessionKey,
+      selectedSessionPreferredModel:
+        inputQuery.selectedSession?.preferredModel ?? undefined,
+      selectedSessionPreferredThinking:
+        inputQuery.selectedSession?.preferredThinking ?? null,
+    });
+  }, [
+    inputActions,
+    inputQuery.defaultModel,
+    inputQuery.fallbackPreferredModel,
+    inputQuery.fallbackPreferredThinking,
+    inputQuery.modelOptions,
+    inputQuery.selectedSession,
+    inputQuery.selectedSessionKey,
+  ]);
   useSessionConversationDraftRouteState({
     sessionKey,
     setPendingProjectRoot: inputActions.setPendingProjectRoot,

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/components/session-conversation-input.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/components/session-conversation-input.tsx
@@ -269,15 +269,9 @@ export const SessionConversationInput = memo(function SessionConversationInput(p
     favoriteModelValues,
     setModelFavorite,
   } = useChatModelFavorites(modelRecordValues);
-  const selectedModel =
-    inputSnapshot.selectedModel ??
-    inputQuery.fallbackPreferredModel ??
-    inputQuery.defaultModel ??
-    '';
+  const selectedModel = inputSnapshot.selectedModel ?? '';
   const selectedThinkingLevel = (
-    inputSnapshot.selectedThinkingLevel ??
-    inputQuery.fallbackPreferredThinking ??
-    null
+    inputSnapshot.selectedThinkingLevel
   ) as ChatThinkingLevel | null;
   const availabilitySnapshot = {
     isProviderStateResolved: inputQuery.isProviderStateResolved,

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/__tests__/use-session-conversation-input-state.test.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/__tests__/use-session-conversation-input-state.test.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useSessionConversationInputState } from '@/features/chat/features/conversation/hooks/use-session-conversation-input-state';
+import type { ChatModelOption } from '@/features/chat/types/chat-input.types';
+
+const MODEL_OPTIONS: ChatModelOption[] = [
+  {
+    value: 'deepseek/deepseek-v4-flash',
+    modelLabel: 'DeepSeek V4 Flash',
+    providerLabel: 'DeepSeek',
+    thinkingCapability: null,
+  },
+  {
+    value: 'minimax/MiniMax-M3',
+    modelLabel: 'MiniMax M3',
+    providerLabel: 'MiniMax',
+    thinkingCapability: null,
+  },
+];
+
+describe('useSessionConversationInputState session preferences', () => {
+  it('restores the switched session model after its metadata becomes available', () => {
+    const { result } = renderHook(() => useSessionConversationInputState());
+
+    act(() => {
+      result.current.inputActions.syncSessionPreferences({
+        modelOptions: MODEL_OPTIONS,
+        selectedSessionExists: true,
+        selectedSessionKey: 'session-a',
+        selectedSessionPreferredModel: 'deepseek/deepseek-v4-flash',
+      });
+    });
+    expect(result.current.inputSnapshot.selectedModel).toBe('deepseek/deepseek-v4-flash');
+
+    act(() => {
+      result.current.inputActions.syncSessionPreferences({
+        modelOptions: MODEL_OPTIONS,
+        selectedSessionExists: false,
+        selectedSessionKey: 'session-b',
+      });
+    });
+    expect(result.current.inputSnapshot.selectedModel).toBe('deepseek/deepseek-v4-flash');
+
+    act(() => {
+      result.current.inputActions.syncSessionPreferences({
+        modelOptions: MODEL_OPTIONS,
+        selectedSessionExists: true,
+        selectedSessionKey: 'session-b',
+        selectedSessionPreferredModel: 'minimax/MiniMax-M3',
+      });
+    });
+    expect(result.current.inputSnapshot.selectedModel).toBe('minimax/MiniMax-M3');
+  });
+});

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/use-session-conversation-input-state.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/use-session-conversation-input-state.ts
@@ -5,6 +5,10 @@ import type { NcpDraftAttachment } from '@nextclaw/ncp-react';
 import type { ThinkingLevel } from '@/shared/lib/api';
 import { DEFAULT_SESSION_TYPE } from '@/features/chat/features/session-type/utils/chat-session-type.utils';
 import { createChatComposerNodesFromDraft } from '@/features/chat/features/input/utils/chat-composer-state.utils';
+import {
+  useSessionConversationPreferenceActions,
+  type SessionConversationPreferenceSyncParams,
+} from '@/features/chat/features/conversation/hooks/use-session-conversation-preference-actions';
 
 type SessionConversationInputStateValue = string | null | undefined;
 type SessionConversationSkillSelection = {
@@ -51,6 +55,7 @@ export type SessionConversationInputActions = {
   readonly removeAttachment: (attachmentId: string) => void;
   readonly setSelectedModel: (model: SessionConversationInputStateValue) => void;
   readonly setSelectedThinkingLevel: (level: ThinkingLevel | null) => void;
+  readonly syncSessionPreferences: (params: SessionConversationPreferenceSyncParams) => void;
   readonly setPendingSessionType: (sessionType: SetStateAction<string>) => void;
   readonly setPendingProjectRoot: (projectRoot: string | null) => void;
   readonly setSelectedSkills: (
@@ -198,13 +203,11 @@ export const useSessionConversationInputState = () => {
     }));
   }, [update]);
 
-  const setSelectedModel = useCallback((model: SessionConversationInputStateValue) => {
-    update({ selectedModel: model });
-  }, [update]);
-
-  const setSelectedThinkingLevel = useCallback((level: ThinkingLevel | null) => {
-    update({ selectedThinkingLevel: level });
-  }, [update]);
+  const preferenceActions = useSessionConversationPreferenceActions({
+    selectedModel: snapshot.selectedModel,
+    selectedThinkingLevel: snapshot.selectedThinkingLevel,
+    updatePreferences: update,
+  });
 
   const setPendingSessionType = useCallback((sessionType: SetStateAction<string>) => {
     update((current) => {
@@ -249,8 +252,7 @@ export const useSessionConversationInputState = () => {
     setAttachments,
     addAttachments,
     removeAttachment,
-    setSelectedModel,
-    setSelectedThinkingLevel,
+    ...preferenceActions,
     setPendingSessionType,
     setPendingProjectRoot,
     setSelectedSkills,
@@ -266,8 +268,7 @@ export const useSessionConversationInputState = () => {
     setAttachments,
     addAttachments,
     removeAttachment,
-    setSelectedModel,
-    setSelectedThinkingLevel,
+    preferenceActions,
     setPendingSessionType,
     setPendingProjectRoot,
     setSelectedSkills,

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/use-session-conversation-preference-actions.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/use-session-conversation-preference-actions.ts
@@ -1,0 +1,94 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+import type { ThinkingLevel } from '@/shared/lib/api';
+import type { ChatModelOption } from '@/features/chat/types/chat-input.types';
+import {
+  resolveSelectedModelValue,
+  resolveSelectedThinkingLevelValue,
+} from '@/features/chat/features/session/utils/chat-session-preference-governance.utils';
+
+type ConversationPreferenceValue = string | null | undefined;
+
+export type SessionConversationPreferenceSyncParams = {
+  readonly defaultModel?: string;
+  readonly fallbackPreferredModel?: string;
+  readonly fallbackPreferredThinking?: ThinkingLevel | null;
+  readonly modelOptions: ChatModelOption[];
+  readonly selectedSessionExists: boolean;
+  readonly selectedSessionKey?: string | null;
+  readonly selectedSessionPreferredModel?: string;
+  readonly selectedSessionPreferredThinking?: ThinkingLevel | null;
+};
+
+type SessionConversationPreferenceActionsParams = {
+  readonly selectedModel: ConversationPreferenceValue;
+  readonly selectedThinkingLevel: ThinkingLevel | null;
+  readonly updatePreferences: (patch: {
+    readonly selectedModel?: ConversationPreferenceValue;
+    readonly selectedThinkingLevel?: ThinkingLevel | null;
+  }) => void;
+};
+
+export const useSessionConversationPreferenceActions = ({
+  selectedModel: currentSelectedModel,
+  selectedThinkingLevel: currentSelectedThinkingLevel,
+  updatePreferences,
+}: SessionConversationPreferenceActionsParams) => {
+  const previousSessionKeyRef = useRef<string | null | undefined>(undefined);
+  const setSelectedModel = useCallback((selectedModel: ConversationPreferenceValue) => {
+    updatePreferences({ selectedModel });
+  }, [updatePreferences]);
+  const setSelectedThinkingLevel = useCallback((selectedThinkingLevel: ThinkingLevel | null) => {
+    updatePreferences({ selectedThinkingLevel });
+  }, [updatePreferences]);
+  const syncSessionPreferences = useCallback(({
+    defaultModel,
+    fallbackPreferredModel,
+    fallbackPreferredThinking,
+    modelOptions,
+    selectedSessionExists,
+    selectedSessionKey: sessionKey,
+    selectedSessionPreferredModel,
+    selectedSessionPreferredThinking,
+  }: SessionConversationPreferenceSyncParams) => {
+    const selectedSessionKey = sessionKey ?? null;
+    const sessionChanged = previousSessionKeyRef.current !== selectedSessionKey;
+    const preserveCurrentPreference = sessionChanged && Boolean(selectedSessionKey) && !selectedSessionExists;
+    const selectedModel = resolveSelectedModelValue({
+      currentSelectedModel: currentSelectedModel ?? undefined,
+      modelOptions,
+      selectedSessionPreferredModel,
+      fallbackPreferredModel,
+      defaultModel,
+      preferSessionPreferredModel: sessionChanged,
+      preserveCurrentSelectedModelOnSessionChange: preserveCurrentPreference,
+    });
+    const modelOption = modelOptions.find((option) => option.value === selectedModel);
+    const selectedThinkingLevel = resolveSelectedThinkingLevelValue({
+      currentSelectedThinkingLevel,
+      supportedThinkingLevels:
+        (modelOption?.thinkingCapability?.supported as ThinkingLevel[] | undefined) ?? [],
+      selectedSessionPreferredThinking,
+      fallbackPreferredThinking,
+      defaultThinkingLevel:
+        (modelOption?.thinkingCapability?.default as ThinkingLevel | null | undefined) ?? null,
+      preferSessionPreferredThinking: sessionChanged,
+      preserveCurrentSelectedThinkingOnSessionChange: preserveCurrentPreference,
+    });
+    if (
+      currentSelectedModel !== selectedModel ||
+      currentSelectedThinkingLevel !== selectedThinkingLevel
+    ) {
+      updatePreferences({ selectedModel, selectedThinkingLevel });
+    }
+    if (!selectedSessionKey || selectedSessionExists) {
+      previousSessionKeyRef.current = selectedSessionKey;
+    }
+  }, [currentSelectedModel, currentSelectedThinkingLevel, updatePreferences]);
+
+  return useMemo(() => ({
+    setSelectedModel,
+    setSelectedThinkingLevel,
+    syncSessionPreferences,
+  }), [setSelectedModel, setSelectedThinkingLevel, syncSessionPreferences]);
+};

--- a/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/__tests__/panel-app-reference-plugin.test.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/__tests__/panel-app-reference-plugin.test.ts
@@ -67,6 +67,7 @@ describe('panel app reference input surface plugin', () => {
     expect(state.panel?.items).toEqual([
       expect.objectContaining({
         key: 'panel-app:task-board',
+        icon: 'panel-app',
         title: 'Task Board',
         tokenKind: 'panel_app',
         tokenKey: 'task-board',

--- a/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/__tests__/slash-command-plugin.test.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/__tests__/slash-command-plugin.test.ts
@@ -125,16 +125,19 @@ describe('createSlashCommandInputSurfacePlugin', () => {
       { key: 'panel-apps', label: 'Panel Apps', sectionKeys: ['panel-apps'] },
     ]);
     expect(state.panel?.items[0]).toMatchObject({
+      icon: 'command',
       sectionKey: 'commands',
       sectionLabel: 'Commands',
       hintLabel: 'Run command',
     });
     expect(state.panel?.items[1]).toMatchObject({
+      icon: 'skill',
       sectionKey: 'skills',
       sectionLabel: 'Skills',
       hintLabel: 'Add skill',
     });
     expect(state.panel?.items[2]).toMatchObject({
+      icon: 'panel-app',
       sectionKey: 'panel-apps',
       sectionLabel: 'Panel Apps',
       hintLabel: 'Open panel app',

--- a/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/panel-app-reference-plugin.utils.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/panel-app-reference-plugin.utils.ts
@@ -85,6 +85,7 @@ function buildPanelAppInputSurfaceItemEntries(params: {
     entry,
     item: {
       key: `${keyPrefix}:${entry.appId}`,
+      icon: 'panel-app',
       title: entry.title || entry.appId,
       subtitle: params.texts.subtitle,
       description: (entry.description ?? '').trim() || params.texts.noDescriptionLabel,

--- a/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/slash-command-plugin.utils.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/input/input-surface-plugins/slash-command-plugin.utils.ts
@@ -69,6 +69,7 @@ function buildSlashCommandItems(params: {
     })
     .map(({ command }) => ({
       key: `command:${command.key}`,
+      icon: 'command',
       title: command.title,
       subtitle: params.texts.commandSubtitle,
       description: command.description,
@@ -103,6 +104,7 @@ function buildSlashSkillItems(params: {
     [...data.recentSkillValues],
   ).map((item) => ({
     ...item,
+    icon: 'skill',
     hintLabel: skillHintLabel,
     sectionKey: item.sectionKey
       ? `${SLASH_SKILL_SECTION_KEY}:${item.sectionKey}`
@@ -125,6 +127,7 @@ function buildSlashPanelAppItems(params: {
     texts: params.itemTexts,
   }).map((item) => ({
     ...item,
+    icon: 'panel-app',
     hintLabel: params.panelAppHintLabel,
     sectionKey: SLASH_PANEL_APP_SECTION_KEY,
     sectionLabel: params.panelAppSectionLabel,

--- a/packages/nextclaw-ui/src/features/chat/features/input/utils/chat-input-bar.utils.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/input/utils/chat-input-bar.utils.ts
@@ -278,6 +278,7 @@ export function buildSkillPickerModel(params: {
   const recentKeySet = new Set(groupedRecentSkillValues ?? []);
   return {
     title: texts.title,
+    allGroupsLabel: texts.allSkillsLabel,
     searchPlaceholder: texts.searchPlaceholder,
     emptyLabel: texts.emptyLabel,
     loadingLabel: texts.loadingLabel,

--- a/packages/nextclaw-ui/src/features/chat/features/ncp/hooks/__tests__/use-hydrated-ncp-agent.test.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/ncp/hooks/__tests__/use-hydrated-ncp-agent.test.tsx
@@ -1,17 +1,55 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import type { NcpAgentClientEndpoint } from "@nextclaw/ncp";
-import { useHydratedNcpAgent } from "@nextclaw/ncp-react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { NcpEventType, type NcpAgentClientEndpoint } from "@nextclaw/ncp";
+import { useHydratedNcpAgent, useNcpAgentRuntime } from "@nextclaw/ncp-react";
+import { DefaultNcpAgentConversationStateManager } from "@nextclaw/ncp-toolkit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
   stream: vi.fn(),
   stop: vi.fn(),
 }));
 
 describe("useHydratedNcpAgent", () => {
   beforeEach(() => {
+    mocks.send.mockReset();
     mocks.stream.mockReset();
     mocks.stop.mockReset();
+  });
+
+  it("clears a draft conversation error when a valid retry starts", async () => {
+    const client = {
+      send: mocks.send.mockResolvedValue(null),
+      stop: mocks.stop.mockResolvedValue(undefined),
+      stream: mocks.stream.mockResolvedValue(undefined),
+      subscribe: vi.fn(() => () => {}),
+    } as unknown as NcpAgentClientEndpoint;
+    const manager = new DefaultNcpAgentConversationStateManager();
+    const { result } = renderHook(() =>
+      useNcpAgentRuntime({
+        client,
+        manager,
+      }),
+    );
+
+    await act(async () => {
+      await manager.dispatch({
+        occurredAt: new Date().toISOString(),
+        type: NcpEventType.EndpointError,
+        payload: {
+          code: "runtime-error",
+          message: "network error",
+        },
+      });
+    });
+    expect(result.current.snapshot.error?.message).toBe("network error");
+
+    await act(async () => {
+      await result.current.send("retry");
+    });
+
+    expect(result.current.snapshot.error).toBeNull();
+    expect(mocks.send).toHaveBeenCalledOnce();
   });
 
   it("treats a newly selected session as hydrating immediately on rerender", async () => {

--- a/packages/nextclaw-ui/src/features/chat/features/session/components/session-header/chat-session-switcher-groups.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/session/components/session-header/chat-session-switcher-groups.tsx
@@ -1,0 +1,245 @@
+import { useId } from "react";
+import { Check, ChevronDown, ChevronRight, Folder } from "lucide-react";
+import type { NcpSessionListItemView } from "@/features/chat/features/ncp/hooks/use-ncp-session-list-view";
+import { SessionContextIconNode } from "@/features/chat/features/session/components/session-context-icon";
+import { SessionRunBadge } from "@/features/chat/features/session/components/session-run-badge";
+import type {
+  ChatSidebarDateGroup,
+  ChatSidebarProjectGroup,
+} from "@/features/chat/features/session/utils/chat-sidebar-session-groups.utils";
+import {
+  formatSessionListTime,
+  sessionActivityPreviewText,
+  sessionDisplayName,
+} from "@/features/chat/features/session/utils/chat-session-display.utils";
+import { resolveSessionContextView } from "@/features/chat/features/session/utils/session-context.utils";
+import type { ChatSessionTypeOption } from "@/features/chat/features/session-type/utils/chat-session-type.utils";
+import { shouldShowUnreadSessionIndicator } from "@/features/chat/stores/chat-session-list.store";
+import { t } from "@/shared/lib/i18n";
+import { cn } from "@/shared/lib/utils";
+
+type SessionSwitchItemsProps = {
+  items: NcpSessionListItemView[];
+  selectedSessionKey: string | null;
+  optimisticReadAtBySessionKey: Record<string, string>;
+  sessionTypeOptions: ChatSessionTypeOption[];
+  onSelect: (sessionKey: string) => void;
+  className?: string;
+};
+
+function ChatSessionSwitchItem({
+  item,
+  selectedSessionKey,
+  optimisticReadAtBySessionKey,
+  sessionTypeOptions,
+  onSelect,
+}: Omit<SessionSwitchItemsProps, "items" | "className"> & {
+  item: NcpSessionListItemView;
+}) {
+  const { session, runStatus } = item;
+  const active = selectedSessionKey === session.key;
+  const optimisticReadAt = optimisticReadAtBySessionKey[session.key];
+  const effectiveReadAt =
+    optimisticReadAt && session.readAt
+      ? optimisticReadAt.localeCompare(session.readAt) > 0
+        ? optimisticReadAt
+        : session.readAt
+      : (optimisticReadAt ?? session.readAt);
+  const shouldShowUnread = shouldShowUnreadSessionIndicator({
+    active,
+    lastMessageAt: session.lastMessageAt,
+    readAt: effectiveReadAt,
+    runStatus,
+  });
+  const previewText =
+    sessionActivityPreviewText(session) ??
+    session.projectName ??
+    session.projectRoot ??
+    `${session.messageCount}`;
+  const trailingText = formatSessionListTime(
+    session.lastMessageAt ?? session.createdAt,
+  );
+  const sessionContext = resolveSessionContextView(session, sessionTypeOptions);
+
+  return (
+    <button
+      type="button"
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "flex w-full min-w-0 items-start gap-2 rounded-lg px-2.5 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-foreground hover:bg-accent/65 hover:text-accent-foreground",
+      )}
+      onClick={() => onSelect(session.key)}
+    >
+      <span className="relative mt-1 flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+        {shouldShowUnread ? (
+          <span
+            aria-label={t("chatSidebarUnread")}
+            className="h-1.5 w-1.5 rounded-full bg-primary"
+          />
+        ) : active ? (
+          <Check className="h-3 w-3 text-primary" />
+        ) : (
+          <span className="h-1 w-1 rounded-full bg-muted-foreground/45" />
+        )}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 flex-1 truncate text-xs font-medium">
+            {sessionDisplayName(session)}
+          </span>
+          {sessionContext.label ? (
+            <span className="shrink-0 rounded-full border border-border/70 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-muted-foreground">
+              {sessionContext.label}
+            </span>
+          ) : null}
+          {sessionContext.icon ? (
+            <span className="inline-flex h-[1.125rem] w-[1.125rem] shrink-0 items-center justify-center text-muted-foreground">
+              <SessionContextIconNode icon={sessionContext.icon} />
+            </span>
+          ) : null}
+        </span>
+        <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-muted-foreground">
+          <span className="min-w-0 truncate">{previewText}</span>
+          <span className="shrink-0">{trailingText}</span>
+        </span>
+      </span>
+      {runStatus ? (
+        <span className="mt-0.5 shrink-0">
+          <SessionRunBadge status={runStatus} />
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function ChatSessionSwitchItems({
+  items,
+  selectedSessionKey,
+  optimisticReadAtBySessionKey,
+  sessionTypeOptions,
+  onSelect,
+  className,
+}: SessionSwitchItemsProps) {
+  return (
+    <div className={cn("space-y-1", className)}>
+      {items.map((item) => (
+        <ChatSessionSwitchItem
+          key={item.session.key}
+          item={item}
+          selectedSessionKey={selectedSessionKey}
+          optimisticReadAtBySessionKey={optimisticReadAtBySessionKey}
+          sessionTypeOptions={sessionTypeOptions}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ChatSessionSwitchDateGroup({
+  group,
+  ...itemsProps
+}: Omit<SessionSwitchItemsProps, "items"> & {
+  group: ChatSidebarDateGroup;
+}) {
+  return (
+    <section aria-label={group.label}>
+      <div className="px-2 py-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+        {group.label}
+      </div>
+      <ChatSessionSwitchItems items={group.items} {...itemsProps} />
+    </section>
+  );
+}
+
+function ChatSessionSwitchProjectGroup({
+  group,
+  isCollapsed,
+  onToggleCollapsed,
+  ...itemsProps
+}: Omit<SessionSwitchItemsProps, "items"> & {
+  group: ChatSidebarProjectGroup;
+  isCollapsed: boolean;
+  onToggleCollapsed: (projectRoot: string) => void;
+}) {
+  const contentId = useId();
+  const actionLabel = `${t(
+    isCollapsed ? "chatSidebarExpandProject" : "chatSidebarCollapseProject",
+  )} · ${group.projectName}`;
+
+  return (
+    <section aria-label={group.projectName}>
+      <button
+        type="button"
+        aria-controls={contentId}
+        aria-expanded={!isCollapsed}
+        aria-label={actionLabel}
+        className="group flex h-10 w-full min-w-0 items-center gap-1.5 rounded-lg px-2 text-left text-muted-foreground transition-colors hover:bg-gray-200/60 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+        onClick={() => onToggleCollapsed(group.projectRoot)}
+      >
+        <Folder className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span
+          className="min-w-0 flex-1 truncate text-[11px] font-medium uppercase tracking-wider"
+          title={group.projectRoot}
+        >
+          {group.projectName}
+        </span>
+        <span className="shrink-0 text-[10px] text-muted-foreground/70">
+          {group.items.length}
+        </span>
+        {isCollapsed ? (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        )}
+      </button>
+      {isCollapsed ? null : (
+        <ChatSessionSwitchItems
+          items={group.items}
+          className="mt-0.5"
+          {...itemsProps}
+        />
+      )}
+    </section>
+  );
+}
+
+export function ChatSessionSwitcherGroups({
+  collapsedProjectRoots,
+  dateGroups,
+  isProjectFirstView,
+  onToggleProjectCollapsed,
+  projectGroups,
+  ...itemsProps
+}: Omit<SessionSwitchItemsProps, "items"> & {
+  collapsedProjectRoots: string[];
+  dateGroups: ChatSidebarDateGroup[];
+  isProjectFirstView: boolean;
+  onToggleProjectCollapsed: (projectRoot: string) => void;
+  projectGroups: ChatSidebarProjectGroup[];
+}) {
+  return (
+    <div className="space-y-3">
+      {isProjectFirstView
+        ? projectGroups.map((group) => (
+            <ChatSessionSwitchProjectGroup
+              key={group.projectRoot}
+              group={group}
+              isCollapsed={collapsedProjectRoots.includes(group.projectRoot)}
+              onToggleCollapsed={onToggleProjectCollapsed}
+              {...itemsProps}
+            />
+          ))
+        : dateGroups.map((group) => (
+            <ChatSessionSwitchDateGroup
+              key={group.label}
+              group={group}
+              {...itemsProps}
+            />
+          ))}
+    </div>
+  );
+}

--- a/packages/nextclaw-ui/src/features/chat/features/session/components/session-header/chat-session-title-switcher.tsx
+++ b/packages/nextclaw-ui/src/features/chat/features/session/components/session-header/chat-session-title-switcher.tsx
@@ -1,33 +1,21 @@
 import { useMemo, useState } from "react";
 import {
-  Check,
   ChevronDown,
   Loader2,
   MessageSquareText,
   Search,
 } from "lucide-react";
 import { usePresenter } from "@/features/chat/components/providers/chat-presenter.provider";
+import { useNcpSessionListView } from "@/features/chat/features/ncp/hooks/use-ncp-session-list-view";
 import {
-  useNcpSessionListView,
-  type NcpSessionListItemView,
-} from "@/features/chat/features/ncp/hooks/use-ncp-session-list-view";
-import { SessionContextIconNode } from "@/features/chat/features/session/components/session-context-icon";
-import { SessionRunBadge } from "@/features/chat/features/session/components/session-run-badge";
-import {
-  formatSessionListTime,
-  sessionActivityPreviewText,
-  sessionDisplayName,
-} from "@/features/chat/features/session/utils/chat-session-display.utils";
-import { sortSessionItemsByActivityAtDesc } from "@/features/chat/features/session/utils/chat-sidebar-session-groups.utils";
-import { resolveSessionContextView } from "@/features/chat/features/session/utils/session-context.utils";
-import {
-  buildSessionTypeOptions,
-  type ChatSessionTypeOption,
-} from "@/features/chat/features/session-type/utils/chat-session-type.utils";
-import {
-  shouldShowUnreadSessionIndicator,
-  useChatSessionListStore,
-} from "@/features/chat/stores/chat-session-list.store";
+  groupSessionsByDate,
+  groupSessionsByProject,
+  sortSessionItemsByActivityAtDesc,
+} from "@/features/chat/features/session/utils/chat-sidebar-session-groups.utils";
+import { ChatSidebarListModeSwitch } from "@/features/chat/components/chat-sidebar-list-mode-switch";
+import { buildSessionTypeOptions } from "@/features/chat/features/session-type/utils/chat-session-type.utils";
+import { useChatSessionListStore } from "@/features/chat/stores/chat-session-list.store";
+import { ChatSessionSwitcherGroups } from "@/features/chat/features/session/components/session-header/chat-session-switcher-groups";
 import { useChatQueryStore } from "@/features/chat/stores/ncp-chat-query.store";
 import { useViewportLayoutStore } from "@/app/stores/viewport-layout.store";
 import {
@@ -68,96 +56,6 @@ function ChatSessionTitleSwitcherLoadingState() {
   );
 }
 
-function ChatSessionSwitchItem({
-  item,
-  selectedSessionKey,
-  optimisticReadAtBySessionKey,
-  sessionTypeOptions,
-  onSelect,
-}: {
-  item: NcpSessionListItemView;
-  selectedSessionKey: string | null;
-  optimisticReadAtBySessionKey: Record<string, string>;
-  sessionTypeOptions: ChatSessionTypeOption[];
-  onSelect: (sessionKey: string) => void;
-}) {
-  const { session, runStatus } = item;
-  const active = selectedSessionKey === session.key;
-  const optimisticReadAt = optimisticReadAtBySessionKey[session.key];
-  const effectiveReadAt =
-    optimisticReadAt && session.readAt
-      ? optimisticReadAt.localeCompare(session.readAt) > 0
-        ? optimisticReadAt
-        : session.readAt
-      : (optimisticReadAt ?? session.readAt);
-  const shouldShowUnread = shouldShowUnreadSessionIndicator({
-    active,
-    lastMessageAt: session.lastMessageAt,
-    readAt: effectiveReadAt,
-    runStatus,
-  });
-  const previewText =
-    sessionActivityPreviewText(session) ??
-    session.projectName ??
-    session.projectRoot ??
-    `${session.messageCount}`;
-  const trailingText = formatSessionListTime(
-    session.lastMessageAt ?? session.createdAt,
-  );
-  const sessionContext = resolveSessionContextView(session, sessionTypeOptions);
-
-  return (
-    <button
-      type="button"
-      aria-current={active ? "page" : undefined}
-      className={cn(
-        "flex w-full min-w-0 items-start gap-2 rounded-lg px-2.5 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
-        active
-          ? "bg-accent text-accent-foreground"
-          : "text-popover-foreground hover:bg-accent/70",
-      )}
-      onClick={() => onSelect(session.key)}
-    >
-      <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
-        {active ? (
-          <Check className="h-3.5 w-3.5" />
-        ) : shouldShowUnread ? (
-          <span
-            aria-label={t("chatSessionUnread")}
-            className="h-2 w-2 rounded-full bg-primary"
-          />
-        ) : null}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex min-w-0 items-center gap-1.5">
-          <span className="min-w-0 truncate text-[13px] font-medium">
-            {sessionDisplayName(session)}
-          </span>
-          {sessionContext.label ? (
-            <span className="shrink-0 rounded-full border border-border/70 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-muted-foreground">
-              {sessionContext.label}
-            </span>
-          ) : null}
-          {sessionContext.icon ? (
-            <span className="inline-flex h-[1.125rem] w-[1.125rem] shrink-0 items-center justify-center text-muted-foreground">
-              <SessionContextIconNode icon={sessionContext.icon} />
-            </span>
-          ) : null}
-        </span>
-        <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-muted-foreground">
-          <span className="min-w-0 truncate">{previewText}</span>
-          <span className="shrink-0">{trailingText}</span>
-        </span>
-      </span>
-      {runStatus ? (
-        <span className="mt-0.5 shrink-0">
-          <SessionRunBadge status={runStatus} />
-        </span>
-      ) : null}
-    </button>
-  );
-}
-
 function ChatSessionTitleSwitcherPopover({
   selectedSessionKey,
   title,
@@ -171,6 +69,18 @@ function ChatSessionTitleSwitcherPopover({
   const optimisticReadAtBySessionKey = useChatSessionListStore(
     (state) => state.optimisticReadAtBySessionKey,
   );
+  const pinnedSessionKeys = useChatSessionListStore(
+    (state) => state.snapshot.pinnedSessionKeys,
+  );
+  const pinnedProjectRoots = useChatSessionListStore(
+    (state) => state.snapshot.pinnedProjectRoots,
+  );
+  const collapsedProjectRoots = useChatSessionListStore(
+    (state) => state.snapshot.collapsedProjectRoots,
+  );
+  const listMode = useChatSessionListStore(
+    (state) => state.snapshot.listMode,
+  );
   const sessionTypesData = useChatQueryStore(
     (state) => state.snapshot.sessionTypesQuery?.data ?? null,
   );
@@ -178,6 +88,18 @@ function ChatSessionTitleSwitcherPopover({
   const sortedItems = useMemo(
     () => sortSessionItemsByActivityAtDesc(items),
     [items],
+  );
+  const dateGroups = useMemo(
+    () => groupSessionsByDate(sortedItems, new Set(pinnedSessionKeys)),
+    [pinnedSessionKeys, sortedItems],
+  );
+  const projectGroups = useMemo(
+    () => groupSessionsByProject(
+      sortedItems,
+      new Set(pinnedSessionKeys),
+      new Set(pinnedProjectRoots),
+    ),
+    [pinnedProjectRoots, pinnedSessionKeys, sortedItems],
   );
   const sessionTypeOptions = useMemo(
     () => buildSessionTypeOptions(sessionTypesData?.options ?? []),
@@ -198,6 +120,16 @@ function ChatSessionTitleSwitcherPopover({
       setSearchQuery("");
     }
   };
+  const sessionListProps = {
+    selectedSessionKey,
+    optimisticReadAtBySessionKey,
+    sessionTypeOptions,
+    onSelect: selectSession,
+  };
+  const isProjectFirstView = listMode === "project-first";
+  const hasVisibleGroups = isProjectFirstView
+    ? projectGroups.length > 0
+    : dateGroups.length > 0;
 
   return (
     <Popover open={isOpen} onOpenChange={updateOpen}>
@@ -222,8 +154,14 @@ function ChatSessionTitleSwitcherPopover({
         className="w-[22rem] max-w-[calc(100vw-2rem)] p-0"
       >
         <div className="space-y-2 border-b border-border px-3 py-2">
-          <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/75">
-            {t("chatSessionSwitcherTitle")}
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/75">
+              {t("chatSessionSwitcherTitle")}
+            </div>
+            <ChatSidebarListModeSwitch
+              isProjectFirstView={isProjectFirstView}
+              onSelectMode={presenter.chatSessionListManager.setListMode}
+            />
           </div>
           <div className="relative">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/65" />
@@ -240,25 +178,27 @@ function ChatSessionTitleSwitcherPopover({
         <div className="max-h-80 overflow-y-auto p-1.5">
           {isLoading ? (
             <ChatSessionTitleSwitcherLoadingState />
-          ) : sortedItems.length > 0 ? (
-            <div className="space-y-1">
-              {sortedItems.map((item) => (
-                <ChatSessionSwitchItem
-                  key={item.session.key}
-                  item={item}
-                  selectedSessionKey={selectedSessionKey}
-                  optimisticReadAtBySessionKey={optimisticReadAtBySessionKey}
-                  sessionTypeOptions={sessionTypeOptions}
-                  onSelect={selectSession}
-                />
-              ))}
-            </div>
+          ) : hasVisibleGroups ? (
+            <ChatSessionSwitcherGroups
+              collapsedProjectRoots={collapsedProjectRoots}
+              dateGroups={dateGroups}
+              isProjectFirstView={isProjectFirstView}
+              onToggleProjectCollapsed={
+                presenter.chatSessionListManager.toggleProjectCollapsed
+              }
+              projectGroups={projectGroups}
+              {...sessionListProps}
+            />
           ) : (
             <ChatSessionTitleSwitcherEmptyState
               label={
                 searchQuery.trim()
                   ? t("chatSessionSwitcherNoResults")
-                  : t("sessionsEmpty")
+                  : t(
+                      isProjectFirstView
+                        ? "chatSidebarProjectViewEmpty"
+                        : "sessionsEmpty",
+                    )
               }
             />
           )}

--- a/scripts/governance/topology/topology-governance-shared.mjs
+++ b/scripts/governance/topology/topology-governance-shared.mjs
@@ -60,7 +60,7 @@ export function readJson(filePath) {
     return JSON.parse(sourceText);
   } catch {
     const normalizedText = sourceText
-      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\*.*?\*\/\s*$/gm, "")
       .replace(/^\s*\/\/.*$/gm, "")
       .replace(/,\s*([}\]])/g, "$1");
     return JSON.parse(normalizedText);

--- a/scripts/governance/topology/topology-governance-shared.test.mjs
+++ b/scripts/governance/topology/topology-governance-shared.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { readJson } from "./topology-governance-shared.mjs";
+
+test("readJson preserves comment markers inside JSONC strings", (context) => {
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "nextclaw-topology-jsonc-"));
+  const fixturePath = path.join(fixtureDir, "tsconfig.json");
+  context.after(() => rmSync(fixtureDir, { force: true, recursive: true }));
+
+  writeFileSync(
+    fixturePath,
+    `{
+      /* Bundler mode */
+      "compilerOptions": {
+        "paths": {
+          "@/*": ["src/*"],
+          "url": ["https://nextclaw.dev/*"],
+        },
+      },
+    }`
+  );
+
+  assert.deepEqual(readJson(fixturePath), {
+    compilerOptions: {
+      paths: {
+        "@/*": ["src/*"],
+        url: ["https://nextclaw.dev/*"]
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- restore the selected session model and thinking preference after asynchronous session metadata arrives
- clear stale conversation errors when a valid retry starts
- add semantic icons to slash and panel-app input surfaces
- keep the skill picker height stable and add source filters for all, NextClaw, global, and built-in skills
- align the collapsed Header session switcher with the sidebar: lightweight time groups, pinned sessions, time/project mode switching, and collapsible compact project groups
- protect running NextClaw instances from unapproved restarts

## Validation
- agent chat UI: 4 files, 44 tests passed
- NextClaw UI: 7 files, 26 tests passed
- NCP toolkit manager: 19 tests passed
- TypeScript checks passed for all five affected packages
- package lint completed with no errors; only unrelated existing warnings remain
- NextClaw UI production build passed
- new-code governance and backlog ratchet passed
- maintainability guard passed with 0 errors
- isolated browser verification passed at `http://127.0.0.1:5176/chat/draft`; the existing 5174 process was not restarted

Linear: https://linear.app/dimstack/issue/NC-123/交互问题