### PR TITLE
fix: fall back to domestic platform API base for browser auth

### DIFF
--- a/packages/nextclaw-service/src/services/platform-auth/platform-auth-commands.service.ts
+++ b/packages/nextclaw-service/src/services/platform-auth/platform-auth-commands.service.ts
@@ -310,24 +310,40 @@ export class PlatformAuthCommands {
   };
 
   startBrowserAuth = async (opts: Pick<LoginCommandOptions, "apiBase"> = {}): Promise<PlatformBrowserAuthStartResult> => {
-    const { platformBase, v1Base, inputApiBase } = resolveProviderConfig(opts);
-    const response = await fetch(`${platformBase}/platform/auth/browser/start`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({})
-    });
-    const raw = await response.text();
-    if (!response.ok) {
-      throw new Error(buildPlatformApiBaseErrorMessage(inputApiBase, readPlatformErrorMessage(raw, response.status)));
+    const { platformBase, v1Base, inputApiBase, platformBaseCandidates } = resolveProviderConfig(opts);
+    let lastError: Error | null = null;
+    let lastEndpoint = "";
+    for (const candidate of platformBaseCandidates) {
+      const endpoint = `${candidate}/platform/auth/browser/start`;
+      lastEndpoint = endpoint;
+      let response: Response;
+      try {
+        response = await fetch(endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({})
+        });
+      } catch (error) {
+        // 网络层失败（DNS/连接/代理），记录后尝试下一个候选地址。
+        lastError = error instanceof Error ? error : new Error(String(error));
+        continue;
+      }
+      const raw = await response.text();
+      if (!response.ok) {
+        throw new Error(buildPlatformApiBaseErrorMessage(inputApiBase, readPlatformErrorMessage(raw, response.status)));
+      }
+      const result = readBrowserAuthStartPayload(raw);
+      return {
+        ...result,
+        platformBase: candidate,
+        v1Base,
+      };
     }
-    const result = readBrowserAuthStartPayload(raw);
-    return {
-      ...result,
-      platformBase,
-      v1Base
-    };
+    throw new Error(
+      `Failed to reach the platform auth endpoint (${lastEndpoint})${lastError ? `: ${lastError.message}` : ""}. Check the network or configure a reachable platform API base.`,
+    );
   };
 
   pollBrowserAuth = async (params: {

--- a/packages/nextclaw-service/src/utils/remote/platform-api-base.utils.ts
+++ b/packages/nextclaw-service/src/utils/remote/platform-api-base.utils.ts
@@ -1,4 +1,5 @@
 const DEFAULT_PLATFORM_API_BASE = "https://ai-gateway-api.nextclaw.io/v1";
+const DOMESTIC_PLATFORM_API_BASE = "https://api.nextclaw.net/v1";
 const INVALID_PLATFORM_HINT =
   `Use ${DEFAULT_PLATFORM_API_BASE} or the platform root URL without a trailing path.`;
 
@@ -23,11 +24,17 @@ export function resolvePlatformApiBase(params: {
   platformBase: string;
   v1Base: string;
   inputApiBase: string;
+  platformBaseCandidates: string[];
 } {
-  const explicitApiBase = typeof params.explicitApiBase === "string" ? params.explicitApiBase.trim() : "";
-  const configuredApiBase = typeof params.configuredApiBase === "string" ? params.configuredApiBase.trim() : "";
-  const fallbackApiBase = params.fallbackApiBase ?? DEFAULT_PLATFORM_API_BASE;
-  const inputApiBase = explicitApiBase || configuredApiBase || (params.requireConfigured ? "" : fallbackApiBase);
+  const {
+    explicitApiBase: explicitApiBaseInput,
+    configuredApiBase: configuredApiBaseInput,
+    fallbackApiBase,
+    requireConfigured,
+  } = params;
+  const explicitApiBase = typeof explicitApiBaseInput === "string" ? explicitApiBaseInput.trim() : "";
+  const configuredApiBase = typeof configuredApiBaseInput === "string" ? configuredApiBaseInput.trim() : "";
+  const inputApiBase = explicitApiBase || configuredApiBase || (requireConfigured ? "" : (fallbackApiBase ?? DEFAULT_PLATFORM_API_BASE));
   if (!inputApiBase) {
     throw new Error("Platform API base is missing. Pass --api-base or run nextclaw login.");
   }
@@ -49,10 +56,22 @@ export function resolvePlatformApiBase(params: {
   }
 
   const normalizedPlatformBase = trimTrailingSlash(parsedUrl.toString());
+  const normalizedDomesticBase = trimTrailingSlash(
+    normalizeExplicitApiBase(DOMESTIC_PLATFORM_API_BASE),
+  );
+  const candidates = [normalizedPlatformBase];
+  if (
+    normalizedDomesticBase &&
+    normalizedDomesticBase !== normalizedPlatformBase
+  ) {
+    // 官方域名直连失败时，自动回退到国内可访问的备用地址。
+    candidates.push(normalizedDomesticBase);
+  }
   return {
     platformBase: normalizedPlatformBase,
     v1Base: `${normalizedPlatformBase}/v1`,
-    inputApiBase
+    inputApiBase,
+    platformBaseCandidates: [...new Set(candidates)],
   };
 }
 

--- a/packages/nextclaw-ui/src/features/account/managers/account.manager.ts
+++ b/packages/nextclaw-ui/src/features/account/managers/account.manager.ts
@@ -1,5 +1,6 @@
 import { logoutRemote, pollRemoteBrowserAuth, startRemoteBrowserAuth, updateRemoteAccountProfile } from '@/shared/lib/api';
 import type { RemoteAccessView } from '@/shared/lib/api';
+import { NextClawClientError } from '@nextclaw/client-sdk';
 import {
   ensureRemoteStatus,
   refreshRemoteStatus,
@@ -79,8 +80,15 @@ export class AccountManager {
       this.scheduleBrowserAuthPoll();
     } catch (error) {
       const message = error instanceof Error ? error.message : t('remoteBrowserAuthStartFailed');
+      // 网络层失败（DNS/代理/平台地址不可达）时，附上实际请求的平台地址便于诊断。
+      const endpoint = error instanceof NextClawClientError
+        ? (typeof error.details?.url === 'string' ? error.details.url : null)
+        : null;
+      const diagnostic = endpoint
+        ? `${message} (${endpoint})`
+        : message;
       this.rejectBrowserSignIn(error);
-      toast.error(`${t('remoteBrowserAuthStartFailed')}: ${message}`);
+      toast.error(`${t('remoteBrowserAuthStartFailed')}: ${diagnostic}`);
     }
   };
 


### PR DESCRIPTION
平台认证接口在网络层失败时不再直接报错：resolvePlatformApiBase 新增国内备用地址（api.nextclaw.net）候选，startBrowserAuth 按候选顺序重试，网络层失败会记录原因并尝试下一个地址；最终失败的错误信息带实际请求地址与原因，账号登录入口 toast 同步展示该地址，便于诊断 DNS/代理/平台可达性问题。
