### PR TITLE
feat: add tool risk policy config schema for confirm flow

### DIFF
--- a/packages/nextclaw-core/src/features/config/configs/config-schema.config.ts
+++ b/packages/nextclaw-core/src/features/config/configs/config-schema.config.ts
@@ -285,6 +285,20 @@ export const AgentsConfigSchema = z.object({
   list: z.array(AgentProfileSchema).default([])
 });
 
+export const ToolRiskLevelSchema = z.enum(["low", "medium", "high", "critical"]);
+
+export const ToolRiskPolicyEntrySchema = z.object({
+  risk: ToolRiskLevelSchema.default("low"),
+  reasonHint: z.string().optional(),
+  requireConfirmWhen: z.array(z.string()).default([])
+});
+
+export const ToolRiskPolicySchema = z.object({
+  entries: z.record(z.string(), ToolRiskPolicyEntrySchema).default({}),
+  confirmTimeoutSec: z.number().int().min(1).default(120),
+  rememberConfirmations: z.boolean().default(true)
+});
+
 export const ProviderConfigSchema = z.object({
   enabled: z.boolean().default(true),
   providerType: z.string().trim().min(1).nullable().optional(),

--- a/packages/nextclaw-core/src/features/config/configs/config-schema.tool-risk-policy.config.test.ts
+++ b/packages/nextclaw-core/src/features/config/configs/config-schema.tool-risk-policy.config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ToolRiskPolicySchema } from "./config-schema.config.js";
+
+describe("ToolRiskPolicySchema", () => {
+  it("applies defaults for an empty policy", () => {
+    const policy = ToolRiskPolicySchema.parse({});
+
+    expect(policy.entries).toEqual({});
+    expect(policy.confirmTimeoutSec).toBe(120);
+    expect(policy.rememberConfirmations).toBe(true);
+  });
+
+  it("keeps explicit risk level, hint and confirm conditions per tool", () => {
+    const policy = ToolRiskPolicySchema.parse({
+      entries: {
+        "fs.remove": {
+          risk: "critical",
+          reasonHint: "删除文件不可恢复，需要用户确认",
+          requireConfirmWhen: ["recursive=true"]
+        },
+        "exec.run": {
+          risk: "high"
+        }
+      },
+      confirmTimeoutSec: 60,
+      rememberConfirmations: false
+    });
+
+    expect(policy.entries["fs.remove"]).toMatchObject({
+      risk: "critical",
+      reasonHint: "删除文件不可恢复，需要用户确认",
+      requireConfirmWhen: ["recursive=true"]
+    });
+    expect(policy.entries["exec.run"]).toMatchObject({
+      risk: "high",
+      requireConfirmWhen: []
+    });
+    expect(policy.entries["exec.run"]).not.toHaveProperty("reasonHint");
+    expect(policy.confirmTimeoutSec).toBe(60);
+    expect(policy.rememberConfirmations).toBe(false);
+  });
+
+  it("defaults an unlisted tool entry to low risk", () => {
+    const policy = ToolRiskPolicySchema.parse({
+      entries: {
+        "fs.read": {}
+      }
+    });
+
+    expect(policy.entries["fs.read"].risk).toBe("low");
+    expect(policy.entries["fs.read"].requireConfirmWhen).toEqual([]);
+  });
+
+  it("rejects an invalid risk level", () => {
+    expect(() =>
+      ToolRiskPolicySchema.parse({
+        entries: {
+          "fs.remove": { risk: "extreme" }
+        }
+      })
+    ).toThrow();
+  });
+
+  it("rejects a non-positive confirm timeout", () => {
+    expect(() => ToolRiskPolicySchema.parse({ confirmTimeoutSec: 0 })).toThrow();
+  });
+});


### PR DESCRIPTION
## 背景

P0「信任与安全闭环」的第一步：为高风险工具确认流提供**配置契约**（纯 schema，不含拦截逻辑）。

## 改动

- 新增 `ToolRiskPolicySchema`（`nextclaw-core` config-schema）：按工具名声明风险等级 `low/medium/high/critical`，支持确认理由（reasonHint）、触发条件（requireConfirmWhen）、确认超时（confirmTimeoutSec，默认 120s）与同会话记忆确认（rememberConfirmations）
- 新增配套单测 5 例（默认值、显式等级/条件、未登记工具默认 low、非法等级与非正超时拒绝）

## 范围

- 纯 schema + 单测，作为后续 dispatch 层确认拦截的配置基础；不包含任何执行/拦截改动
- 与既有 `ContextConfigSchema`/`AgentsConfigSchema` 风格对齐，owner 归 `nextclaw-core`

## 验收

- 单测 5/5 通过；`lint:new-code:governance` 全绿
