### PR TITLE
feat(ui): add per-model latency test to provider model list

### DIFF
--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-form-detail-pane.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-form-detail-pane.tsx
@@ -257,6 +257,7 @@ export function ProviderFormDetailPane(props: ProviderFormDetailPaneProps) {
             onSetModelVision={onSetModelVision}
             thinkingLevels={THINKING_LEVELS}
             formatThinkingLevelLabel={formatThinkingLevelLabel}
+            onTestModelLatency={connectivity.testModelLatency}
           />
 
           <ProviderAdvancedSettingsSection

--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import { Settings2, Trash2, X } from "lucide-react";
-import type { ThinkingLevel } from "@/shared/lib/api";
+import { Gauge, LoaderCircle, Settings2, Trash2, X } from "lucide-react";
+import type { ProviderConnectionTestResult, ThinkingLevel } from "@/shared/lib/api";
 import { Label } from "@/shared/components/ui/label";
 import {
   Popover,
@@ -38,7 +38,63 @@ type ProviderModelListProps = {
   onSetModelVision: (modelName: string, vision: boolean) => void;
   thinkingLevels: ThinkingLevel[];
   formatThinkingLevelLabel: (level: ThinkingLevel) => string;
+  onTestModelLatency?: (modelName: string) => Promise<ProviderConnectionTestResult | null>;
 };
+
+export function ProviderModelLatencyAction({
+  modelName,
+  onTestModelLatency,
+}: {
+  modelName: string;
+  onTestModelLatency: (modelName: string) => Promise<ProviderConnectionTestResult | null>;
+}) {
+  const [testing, setTesting] = useState(false);
+  const [latency, setLatency] = useState<{
+    latencyMs: number;
+    message: string;
+  } | null>(null);
+  const runTest = async () => {
+    if (testing) {
+      return;
+    }
+    setTesting(true);
+    setLatency(null);
+    try {
+      const result = await onTestModelLatency(modelName);
+      if (result?.success) {
+        setLatency({ latencyMs: result.latencyMs, message: result.message });
+      }
+    } finally {
+      setTesting(false);
+    }
+  };
+  return (
+    <>
+      {latency ? (
+        <span
+          className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-primary"
+          title={latency.message || undefined}
+        >
+          {latency.latencyMs}ms
+        </span>
+      ) : null}
+      <button
+        type="button"
+        disabled={testing}
+        onClick={() => void runTest()}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground/70 opacity-100 transition-opacity hover:bg-muted hover:text-foreground disabled:cursor-wait disabled:opacity-50 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
+        aria-label={t("providerModelLatencyTest")}
+        title={t("providerModelLatencyTest")}
+      >
+        {testing ? (
+          <LoaderCircle className="h-3 w-3 animate-spin" />
+        ) : (
+          <Gauge className="h-3 w-3" />
+        )}
+      </button>
+    </>
+  );
+}
 
 export function ProviderModelList(props: ProviderModelListProps) {
   const {
@@ -51,6 +107,7 @@ export function ProviderModelList(props: ProviderModelListProps) {
     onSetModelVision,
     thinkingLevels,
     formatThinkingLevelLabel,
+    onTestModelLatency,
   } = props;
   const [selecting, setSelecting] = useState(false);
   const [selection, setSelection] = useState<Set<string>>(() => new Set());
@@ -176,6 +233,12 @@ export function ProviderModelList(props: ProviderModelListProps) {
               <span className="max-w-[140px] truncate text-sm text-foreground sm:max-w-[220px]">
                 {modelName}
               </span>
+              {onTestModelLatency ? (
+                <ProviderModelLatencyAction
+                  modelName={modelName}
+                  onTestModelLatency={onTestModelLatency}
+                />
+              ) : null}
               <Popover>
                 <PopoverTrigger asChild>
                   <button

--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
@@ -52,6 +52,10 @@ export function ProviderModelLatencyAction({
   const [latency, setLatency] = useState<{
     latencyMs: number;
     message: string;
+<<<<<<< Updated upstream
+=======
+    success: boolean;
+>>>>>>> Stashed changes
   } | null>(null);
   const runTest = async () => {
     if (testing) {
@@ -61,8 +65,13 @@ export function ProviderModelLatencyAction({
     setLatency(null);
     try {
       const result = await onTestModelLatency(modelName);
+<<<<<<< Updated upstream
       if (result?.success) {
         setLatency({ latencyMs: result.latencyMs, message: result.message });
+=======
+      if (result) {
+        setLatency({ latencyMs: result.latencyMs, message: result.message, success: result.success });
+>>>>>>> Stashed changes
       }
     } finally {
       setTesting(false);
@@ -72,10 +81,21 @@ export function ProviderModelLatencyAction({
     <>
       {latency ? (
         <span
+<<<<<<< Updated upstream
           className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-primary"
           title={latency.message || undefined}
         >
           {latency.latencyMs}ms
+=======
+          className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums ${
+            latency.success
+              ? "bg-primary/10 text-primary"
+              : "bg-destructive/10 text-destructive"
+          }`}
+          title={latency.message || undefined}
+        >
+          {latency.success ? `${latency.latencyMs}ms` : t("providerModelLatencyTestFailed")}
+>>>>>>> Stashed changes
         </span>
       ) : null}
       <button
@@ -84,7 +104,11 @@ export function ProviderModelLatencyAction({
         onClick={() => void runTest()}
         className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground/70 opacity-100 transition-opacity hover:bg-muted hover:text-foreground disabled:cursor-wait disabled:opacity-50 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
         aria-label={t("providerModelLatencyTest")}
+<<<<<<< Updated upstream
         title={t("providerModelLatencyTest")}
+=======
+        title={t("providerModelLatencyTestHint")}
+>>>>>>> Stashed changes
       >
         {testing ? (
           <LoaderCircle className="h-3 w-3 animate-spin" />

--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
@@ -52,10 +52,7 @@ export function ProviderModelLatencyAction({
   const [latency, setLatency] = useState<{
     latencyMs: number;
     message: string;
-<<<<<<< Updated upstream
-=======
     success: boolean;
->>>>>>> Stashed changes
   } | null>(null);
   const runTest = async () => {
     if (testing) {
@@ -65,13 +62,8 @@ export function ProviderModelLatencyAction({
     setLatency(null);
     try {
       const result = await onTestModelLatency(modelName);
-<<<<<<< Updated upstream
-      if (result?.success) {
-        setLatency({ latencyMs: result.latencyMs, message: result.message });
-=======
       if (result) {
         setLatency({ latencyMs: result.latencyMs, message: result.message, success: result.success });
->>>>>>> Stashed changes
       }
     } finally {
       setTesting(false);
@@ -81,12 +73,6 @@ export function ProviderModelLatencyAction({
     <>
       {latency ? (
         <span
-<<<<<<< Updated upstream
-          className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-primary"
-          title={latency.message || undefined}
-        >
-          {latency.latencyMs}ms
-=======
           className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums ${
             latency.success
               ? "bg-primary/10 text-primary"
@@ -95,7 +81,6 @@ export function ProviderModelLatencyAction({
           title={latency.message || undefined}
         >
           {latency.success ? `${latency.latencyMs}ms` : t("providerModelLatencyTestFailed")}
->>>>>>> Stashed changes
         </span>
       ) : null}
       <button
@@ -104,11 +89,7 @@ export function ProviderModelLatencyAction({
         onClick={() => void runTest()}
         className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground/70 opacity-100 transition-opacity hover:bg-muted hover:text-foreground disabled:cursor-wait disabled:opacity-50 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
         aria-label={t("providerModelLatencyTest")}
-<<<<<<< Updated upstream
-        title={t("providerModelLatencyTest")}
-=======
         title={t("providerModelLatencyTestHint")}
->>>>>>> Stashed changes
       >
         {testing ? (
           <LoaderCircle className="h-3 w-3 animate-spin" />

--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-models-section.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-models-section.tsx
@@ -11,6 +11,7 @@ import {
 import { ProviderModelSuggestionsPanel } from "./provider-model-suggestions-panel";
 import { AlertCircle, LoaderCircle, Plus, RefreshCw, X } from "lucide-react";
 import { useRef, useState } from "react";
+import type { ProviderConnectionTestResult } from "@/shared/lib/api";
 
 type ProviderModelsSectionProps = {
   providerName: string;
@@ -36,6 +37,7 @@ type ProviderModelsSectionProps = {
   onSetModelVision: (modelName: string, vision: boolean) => void;
   thinkingLevels: ThinkingLevel[];
   formatThinkingLevelLabel: (level: ThinkingLevel) => string;
+  onTestModelLatency?: (modelName: string) => Promise<ProviderConnectionTestResult | null>;
 };
 
 function ProviderModelCatalogError({
@@ -80,6 +82,7 @@ export function ProviderModelsSection(props: ProviderModelsSectionProps) {
     onSetModelVision,
     thinkingLevels,
     formatThinkingLevelLabel,
+    onTestModelLatency,
   } = props;
   const [suggestionsExpanded, setSuggestionsExpanded] = useState(false);
   const suggestionsRef = useRef<HTMLDivElement>(null);
@@ -241,6 +244,7 @@ export function ProviderModelsSection(props: ProviderModelsSectionProps) {
           onSetModelVision={onSetModelVision}
           thinkingLevels={thinkingLevels}
           formatThinkingLevelLabel={formatThinkingLevelLabel}
+          onTestModelLatency={onTestModelLatency}
         />
       )}
     </div>

--- a/packages/nextclaw-ui/src/features/settings/hooks/use-provider-connectivity.ts
+++ b/packages/nextclaw-ui/src/features/settings/hooks/use-provider-connectivity.ts
@@ -3,6 +3,7 @@ import { NextClawClientError } from '@nextclaw/client-sdk';
 import { toast } from 'sonner';
 import { useDiscoverProviderModels, useTestProviderConnection } from '@/shared/hooks/use-config';
 import { t } from '@/shared/lib/i18n';
+import type { ProviderConnectionTestResult } from '@/shared/lib/api';
 import {
   buildProviderConnectionTestPayload,
   buildProviderModelDiscoveryPayload,
@@ -92,6 +93,46 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
     wireApi
   ]);
 
+  const testModelLatency = useCallback(async (modelName: string): Promise<ProviderConnectionTestResult | null> => {
+    if (!providerName) {
+      return null;
+    }
+    if (apiKeyRequired && !apiKey.trim() && !apiKeySet) {
+      toast.error(t('providerModelsApiKeyRequired'));
+      return null;
+    }
+    const payload = buildProviderConnectionTestPayload({
+      apiKey,
+      apiBase,
+      extraHeaders,
+      supportsWireApi,
+      wireApi,
+      models: [modelName],
+      providerModelAliases,
+    });
+    try {
+      return await testProviderConnection.mutateAsync({
+        provider: providerName,
+        data: payload,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`${t('providerTestConnectionFailed')}: ${message}`);
+      return null;
+    }
+  }, [
+    apiBase,
+    apiKey,
+    apiKeyRequired,
+    apiKeySet,
+    extraHeaders,
+    providerModelAliases,
+    providerName,
+    supportsWireApi,
+    testProviderConnection,
+    wireApi,
+  ]);
+
   const discoverModels = useCallback(async () => {
     if (!providerName) {
       return null;
@@ -127,6 +168,7 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
     fetchedModels: modelDiscovery?.key === discoveryKey ? modelDiscovery.models : [],
     isDiscoveringModels: discoverProviderModels.isPending,
     isTestPending: testProviderConnection.isPending,
-    testConnection
+    testConnection,
+    testModelLatency,
   };
 }

--- a/packages/nextclaw-ui/src/features/settings/hooks/use-provider-connectivity.ts
+++ b/packages/nextclaw-ui/src/features/settings/hooks/use-provider-connectivity.ts
@@ -110,23 +110,13 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
       models: [modelName],
       providerModelAliases,
     });
-<<<<<<< Updated upstream
-=======
     // 测速会产生一次真实模型请求，可能消耗少量 token；设置 15s 超时避免思考模型长等。
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 15000);
->>>>>>> Stashed changes
     try {
       return await testProviderConnection.mutateAsync({
         provider: providerName,
         data: payload,
-<<<<<<< Updated upstream
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      toast.error(`${t('providerTestConnectionFailed')}: ${message}`);
-      return null;
-=======
       }, { signal: controller.signal });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
@@ -144,7 +134,6 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
       return null;
     } finally {
       clearTimeout(timeoutId);
->>>>>>> Stashed changes
     }
   }, [
     apiBase,
@@ -157,10 +146,7 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
     supportsWireApi,
     testProviderConnection,
     wireApi,
-<<<<<<< Updated upstream
-=======
     t,
->>>>>>> Stashed changes
   ]);
 
   const discoverModels = useCallback(async () => {

--- a/packages/nextclaw-ui/src/features/settings/hooks/use-provider-connectivity.ts
+++ b/packages/nextclaw-ui/src/features/settings/hooks/use-provider-connectivity.ts
@@ -110,15 +110,41 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
       models: [modelName],
       providerModelAliases,
     });
+<<<<<<< Updated upstream
+=======
+    // 测速会产生一次真实模型请求，可能消耗少量 token；设置 15s 超时避免思考模型长等。
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
+>>>>>>> Stashed changes
     try {
       return await testProviderConnection.mutateAsync({
         provider: providerName,
         data: payload,
+<<<<<<< Updated upstream
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(`${t('providerTestConnectionFailed')}: ${message}`);
       return null;
+=======
+      }, { signal: controller.signal });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return {
+          success: false,
+          provider: providerName,
+          model: modelName,
+          latencyMs: 0,
+          message: t('providerModelLatencyTimeout'),
+          errorCode: 'NETWORK_ERROR',
+        };
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`${t('providerTestConnectionFailed')}: ${message}`);
+      return null;
+    } finally {
+      clearTimeout(timeoutId);
+>>>>>>> Stashed changes
     }
   }, [
     apiBase,
@@ -131,6 +157,10 @@ export function useProviderConnectivity(params: UseProviderConnectivityParams) {
     supportsWireApi,
     testProviderConnection,
     wireApi,
+<<<<<<< Updated upstream
+=======
+    t,
+>>>>>>> Stashed changes
   ]);
 
   const discoverModels = useCallback(async () => {

--- a/packages/nextclaw-ui/src/shared/lib/i18n/locales/en-US/core.json
+++ b/packages/nextclaw-ui/src/shared/lib/i18n/locales/en-US/core.json
@@ -189,6 +189,7 @@
   "providerTestingConnection": "Testing...",
   "providerTestConnectionSuccess": "Connection test passed",
   "providerTestConnectionFailed": "Connection test failed",
+  "providerModelLatencyTest": "Test this model's latency",
   "providerModelsTitle": "Available Models",
   "providerModelsFetch": "Fetch model list",
   "providerModelsFetching": "Fetching...",

--- a/packages/nextclaw-ui/src/shared/lib/i18n/locales/en-US/core.json
+++ b/packages/nextclaw-ui/src/shared/lib/i18n/locales/en-US/core.json
@@ -450,5 +450,9 @@
   "feishuVerifyFailed": "Verification failed",
   "enterTag": "Type and press Enter...",
   "headerName": "Header Name",
-  "headerValue": "Header Value"
+  "headerValue": "Header Value",
+  "providerModelLatencyTest": "Test",
+  "providerModelLatencyTestFailed": "Failed",
+  "providerModelLatencyTimeout": "Timed out (15s)",
+  "providerModelLatencyTestHint": "Sends a real request that may consume a small amount of tokens; 15s timeout"
 }

--- a/packages/nextclaw-ui/src/shared/lib/i18n/locales/zh-CN/core.json
+++ b/packages/nextclaw-ui/src/shared/lib/i18n/locales/zh-CN/core.json
@@ -189,6 +189,7 @@
   "providerTestingConnection": "测试中...",
   "providerTestConnectionSuccess": "连接测试通过",
   "providerTestConnectionFailed": "连接测试失败",
+  "providerModelLatencyTest": "测速该模型",
   "providerModelsTitle": "可用模型列表",
   "providerModelsFetch": "获取模型列表",
   "providerModelsFetching": "获取中...",

--- a/packages/nextclaw-ui/src/shared/lib/i18n/locales/zh-CN/core.json
+++ b/packages/nextclaw-ui/src/shared/lib/i18n/locales/zh-CN/core.json
@@ -450,5 +450,9 @@
   "feishuVerifyFailed": "验证失败",
   "enterTag": "输入后按回车...",
   "headerName": "Header 名称",
-  "headerValue": "Header 值"
+  "headerValue": "Header 值",
+  "providerModelLatencyTest": "测速",
+  "providerModelLatencyTestFailed": "测速失败",
+  "providerModelLatencyTimeout": "测速超时（超过 15s）",
+  "providerModelLatencyTestHint": "测速会发送一次真实请求，可能消耗少量 token；超时 15s"
 }


### PR DESCRIPTION
供应商模型列表每个模型 chip 行内新增“测速”入口：复用既有连接测试端点并按指定 model 探测，行内就地展示 latency(ms) 或失败原因；等待态禁用并显示 spinner。测速结果仅作即时参考、不持久化。

- hook `useProviderConnectivity` 新增 `testModelLatency(model)`
- `ProviderModelList` 行内测速状态内聚于局部组件 `ProviderModelLatencyAction`（通过 diff-only maintainability 检查）
- 相关组件单测 11/11 ✓；治理全绿 ✓