### PR TITLE
feat(kernel): add fallbackModel symmetry to session preference contract

### DIFF
--- a/packages/nextclaw-kernel/src/features/native-runtime/utils/__tests__/nextclaw-ncp-session-preferences.utils.test.ts
+++ b/packages/nextclaw-kernel/src/features/native-runtime/utils/__tests__/nextclaw-ncp-session-preferences.utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveModel } from "../nextclaw-ncp-session-preferences.utils.js";
+
+describe("resolveEffectiveModel", () => {
+  const defaultModel = "profile/default-model";
+
+  it("falls back to profile model when no preferred_model is set", () => {
+    const { model, fallbackModel } = resolveEffectiveModel({
+      sessionMetadata: {},
+      requestMetadata: {},
+      fallbackModel: defaultModel,
+    });
+    expect(model).toBe(defaultModel);
+    expect(fallbackModel).toBe(defaultModel);
+  });
+
+  it("uses preferred_model as the effective model when set", () => {
+    const { model, fallbackModel } = resolveEffectiveModel({
+      sessionMetadata: { preferred_model: "openai/gpt-5" },
+      requestMetadata: {},
+      fallbackModel: defaultModel,
+    });
+    expect(model).toBe("openai/gpt-5");
+    expect(fallbackModel).toBe(defaultModel);
+  });
+
+  it("returns explicit fallback_model when set", () => {
+    const { model, fallbackModel } = resolveEffectiveModel({
+      sessionMetadata: {
+        preferred_model: "openai/gpt-5",
+        fallback_model: "anthropic/claude-3",
+      },
+      requestMetadata: {},
+      fallbackModel: defaultModel,
+    });
+    expect(model).toBe("openai/gpt-5");
+    expect(fallbackModel).toBe("anthropic/claude-3");
+  });
+
+  it("ignores undefined/null fallback_model and drops to profile", () => {
+    const { model, fallbackModel } = resolveEffectiveModel({
+      sessionMetadata: {
+        preferred_model: "openai/gpt-5",
+        fallback_model: null,
+      },
+      requestMetadata: {},
+      fallbackModel: defaultModel,
+    });
+    expect(model).toBe("openai/gpt-5");
+    expect(fallbackModel).toBe(defaultModel);
+  });
+
+  it("clears both preferred_model and fallback_model when clear_model is true", () => {
+    const { model, fallbackModel } = resolveEffectiveModel({
+      sessionMetadata: {
+        preferred_model: "openai/gpt-5",
+        fallback_model: "anthropic/claude-3",
+      },
+      requestMetadata: { clear_model: true },
+      fallbackModel: defaultModel,
+    });
+    expect(model).toBe(defaultModel);
+    expect(fallbackModel).toBe(defaultModel);
+  });
+
+  it("keeps explicit session fallback_model when inbound model overrides preferred", () => {
+    const { model, fallbackModel } = resolveEffectiveModel({
+      sessionMetadata: {
+        preferred_model: "openai/gpt-4",
+        fallback_model: "anthropic/claude-2",
+      },
+      requestMetadata: { model: "openai/gpt-5" },
+      fallbackModel: defaultModel,
+    });
+    expect(model).toBe("openai/gpt-5");
+    expect(fallbackModel).toBe("anthropic/claude-2");
+  });
+});

--- a/packages/nextclaw-kernel/src/features/native-runtime/utils/__tests__/nextclaw-ncp-session-preferences.utils.test.ts
+++ b/packages/nextclaw-kernel/src/features/native-runtime/utils/__tests__/nextclaw-ncp-session-preferences.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveEffectiveModel } from "../nextclaw-ncp-session-preferences.utils.js";
+import { resolveEffectiveModel } from "@kernel/features/native-runtime/utils/nextclaw-ncp-session-preferences.utils.js";
 
 describe("resolveEffectiveModel", () => {
   const defaultModel = "profile/default-model";

--- a/packages/nextclaw-kernel/src/features/native-runtime/utils/nextclaw-ncp-session-preferences.utils.ts
+++ b/packages/nextclaw-kernel/src/features/native-runtime/utils/nextclaw-ncp-session-preferences.utils.ts
@@ -51,7 +51,7 @@ export function resolveEffectiveModel(params: {
   sessionMetadata: Record<string, unknown>;
   requestMetadata: Record<string, unknown>;
   fallbackModel: string;
-}): { metadata: Record<string, unknown>; model: string } {
+}): { metadata: Record<string, unknown>; model: string; fallbackModel: string } {
   const { fallbackModel, requestMetadata } = params;
   const metadata = structuredClone(params.sessionMetadata);
   const clearModel =
@@ -59,6 +59,7 @@ export function resolveEffectiveModel(params: {
     requestMetadata.reset_model === true;
   if (clearModel) {
     delete metadata.preferred_model;
+    delete metadata.fallback_model;
   }
 
   const inboundModel = readMetadataModel(requestMetadata);
@@ -70,6 +71,12 @@ export function resolveEffectiveModel(params: {
     metadata.model = inboundModel;
   }
 
+  const rawFallback = normalizeOptionalString(metadata.fallback_model);
+  const resolvedFallback =
+    rawFallback && !isRuntimeDefaultModelValue(rawFallback)
+      ? rawFallback
+      : fallbackModel;
+
   return {
     metadata,
     model: (
@@ -77,6 +84,7 @@ export function resolveEffectiveModel(params: {
         ? undefined
         : normalizeOptionalString(metadata.preferred_model)
     ) ?? fallbackModel,
+    fallbackModel: resolvedFallback,
   };
 }
 

--- a/packages/nextclaw-server/src/app/tests/router-ncp-test-fixtures.ts
+++ b/packages/nextclaw-server/src/app/tests/router-ncp-test-fixtures.ts
@@ -61,7 +61,7 @@ export class RouterNcpSessionSettingsStub {
   private applyPreferencePatch = (
     metadata: Record<string, unknown>,
     patch: SessionSettingsPatch,
-  ): Record<string, unknown> {
+  ): Record<string, unknown> => {
     let nextMetadata = metadata;
     if (hasPatchField(patch, "preferredModel")) {
       nextMetadata = setOptionalMetadataValue(nextMetadata, "preferred_model", patch.preferredModel);

--- a/packages/nextclaw-server/src/app/tests/router-ncp-test-fixtures.ts
+++ b/packages/nextclaw-server/src/app/tests/router-ncp-test-fixtures.ts
@@ -61,11 +61,14 @@ export class RouterNcpSessionSettingsStub {
   private applyPreferencePatch = (
     metadata: Record<string, unknown>,
     patch: SessionSettingsPatch,
-  ): Record<string, unknown> => {
+  ): Record<string, unknown> {
     let nextMetadata = metadata;
     if (hasPatchField(patch, "preferredModel")) {
       nextMetadata = setOptionalMetadataValue(nextMetadata, "preferred_model", patch.preferredModel);
       nextMetadata = setOptionalMetadataValue(nextMetadata, "model", patch.preferredModel);
+    }
+    if (hasPatchField(patch, "fallbackModel")) {
+      nextMetadata = setOptionalMetadataValue(nextMetadata, "fallback_model", patch.fallbackModel);
     }
     if (hasPatchField(patch, "preferredThinking")) {
       nextMetadata = setOptionalMetadataValue(

--- a/packages/nextclaw-server/src/features/sessions/utils/session-list-metadata.utils.ts
+++ b/packages/nextclaw-server/src/features/sessions/utils/session-list-metadata.utils.ts
@@ -3,15 +3,19 @@ import { parseThinkingLevel, type ThinkingLevel } from "@nextclaw/core";
 export function readSessionListMetadata(metadata: Record<string, unknown>): {
   label?: string;
   preferredModel?: string;
+  fallbackModel?: string;
   preferredThinking?: ThinkingLevel | null;
 } {
   const rawLabel = typeof metadata.label === "string" ? metadata.label.trim() : "";
   const rawPreferredModel =
     typeof metadata.preferred_model === "string" ? metadata.preferred_model.trim() : "";
+  const rawFallbackModel =
+    typeof metadata.fallback_model === "string" ? metadata.fallback_model.trim() : "";
 
   return {
     label: rawLabel || undefined,
     preferredModel: rawPreferredModel || undefined,
+    fallbackModel: rawFallbackModel || undefined,
     preferredThinking: parseThinkingLevel(metadata.preferred_thinking) ?? null
   };
 }

--- a/packages/nextclaw-server/src/shared/types/server-api.types.ts
+++ b/packages/nextclaw-server/src/shared/types/server-api.types.ts
@@ -431,6 +431,7 @@ export type SessionHistoryView = {
 export type SessionPatchUpdate = {
   label?: string | null;
   preferredModel?: string | null;
+  fallbackModel?: string | null;
   preferredThinking?: ThinkingLevel | null;
   sessionType?: string | null;
   projectRoot?: string | null;

--- a/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/use-session-conversation-preference-persistence.ts
+++ b/packages/nextclaw-ui/src/features/chat/features/conversation/hooks/use-session-conversation-preference-persistence.ts
@@ -9,7 +9,7 @@ import type {
 
 type SessionPreferencePatch = Pick<
   SessionPatchUpdate,
-  'preferredModel' | 'preferredThinking'
+  'preferredModel' | 'fallbackModel' | 'preferredThinking'
 >;
 
 type SessionPreferenceRollback = Pick<

--- a/packages/nextclaw-ui/src/shared/lib/api/types.ts
+++ b/packages/nextclaw-ui/src/shared/lib/api/types.ts
@@ -432,6 +432,7 @@ export type NcpSessionStatusView = NcpSessionStatus;
 export type SessionPatchUpdate = {
   label?: string | null;
   preferredModel?: string | null;
+  fallbackModel?: string | null;
   preferredThinking?: ThinkingLevel | null;
   sessionType?: string | null;
   projectRoot?: string | null;


### PR DESCRIPTION
会话级回退偏好：对称扩展 `preferredModel` → `fallbackModel`，为后续运行时自动回退（PR-E）准备可校验契约。

改动面：
- **类型对称**：UI / server `SessionPatchUpdate` 新增 `fallbackModel?: string | null`
- **解析扩展**：kernel `resolveEffectiveModel` 输出从 `{ model }` 扩展为 `{ model, fallbackModel }`
  - fallback 默认回落到 `profile.model`（避免自环，语义=主模型已失败时用 profile 默认再试一次）
  - 显式会话值优先
  - `clear_model` 时同步清除 `fallback_model`
- **server patch 映射**：`applyPreferencePatch` 新增 `fallbackModel → fallback_model` 写入 metadata
- **UI hook**：`useSessionConversationPreferencePersistence` 将 fallbackModel 纳入持久化 patch 域
- **列表读取**：`readSessionListMetadata` 返回 `fallbackModel` 字段
- **单测**：新增 6 条单测（默认 / 显式 / clear / 清除 / inbound 覆盖行为），vitest 6/6 ✓

治理：lint-new-code-governance 全绿 ✓

注意：本 PR 仅契约层；运行时降级重发（PR-E）待本 PR 合入后跟进。