### PR TITLE
feat(kernel): add pinned facts layer to agent bootstrap context

### DIFF
--- a/packages/nextclaw-core/src/features/config/configs/config-schema.config.ts
+++ b/packages/nextclaw-core/src/features/config/configs/config-schema.config.ts
@@ -259,7 +259,9 @@ export const ContextBootstrapSchema = z.object({
     ]),
   minimalFiles: z.array(z.string()).default(["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md"]),
   perFileChars: z.number().int().default(4000),
-  totalChars: z.number().int().default(12000)
+  totalChars: z.number().int().default(12000),
+  /** 用户固定事实文件：最高优先、贴近决策尾部注入，不被记忆压缩裁剪 */
+  pinnedFile: z.string().default("pinned.md")
 });
 
 export const ContextMemorySchema = z.object({

--- a/packages/nextclaw-kernel/src/contributions/context-provider/providers/agent-bootstrap-context.provider.test.ts
+++ b/packages/nextclaw-kernel/src/contributions/context-provider/providers/agent-bootstrap-context.provider.test.ts
@@ -54,6 +54,7 @@ function createContext(workspace: string): ContextProviderRunContextService {
           minimalFiles: ["AGENTS.md"],
           perFileChars: 4000,
           totalChars: 12000,
+          pinnedFile: "pinned.md",
         },
         memory: {
           enabled: false,
@@ -103,5 +104,58 @@ describe("AgentBootstrapContextProvider", () => {
     expect(context).not.toContain("USER.md");
     expect(context).not.toContain("Startup instructions.");
     expect(context).not.toContain("Ask for assistant name before doing anything.");
+  });
+
+  it("injects pinned facts even for compacted sessions and places them at the tail", async () => {
+    const workspace = createWorkspace();
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(workspace, "AGENTS.md"), "Durable project rules.");
+    writeFileSync(join(workspace, "pinned.md"), "Call me 小墨. Never mention the surprise party.");
+
+    const blocks = await new AgentBootstrapContextProvider(createContext(workspace))
+      .provide(createRequest(workspace));
+    const context = blocks.join("\n\n");
+
+    expect(context).toContain("## pinned.md\n\nCall me 小墨.");
+    expect(context.indexOf("pinned.md")).toBeGreaterThan(context.indexOf("AGENTS.md"));
+  });
+
+  it("keeps pinned facts when custom pinnedFile is configured", async () => {
+    const workspace = createWorkspace();
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(workspace, "AGENTS.md"), "Durable project rules.");
+    writeFileSync(join(workspace, "facts.md"), "The server host is prod-01.");
+
+    const contextService = createContext(workspace);
+    contextService.resolve = async () => {
+      const resolved = await (contextService as unknown as {
+        resolveRaw: ContextProviderRunContextService["resolve"];
+      }).resolveRaw();
+      return {
+        ...resolved,
+        contextConfig: {
+          bootstrap: {
+            files: ["AGENTS.md"],
+            minimalFiles: ["AGENTS.md"],
+            perFileChars: 4000,
+            totalChars: 12000,
+            pinnedFile: "facts.md",
+          },
+          memory: {
+            enabled: false,
+            maxChars: 0,
+          },
+        },
+      };
+    };
+    (contextService as unknown as {
+      resolveRaw: ContextProviderRunContextService["resolve"];
+    }).resolveRaw = createContext(workspace).resolve;
+
+    const blocks = await new AgentBootstrapContextProvider(contextService)
+      .provide(createRequest(workspace));
+    const context = blocks.join("\n\n");
+
+    expect(context).toContain("## facts.md\n\nThe server host is prod-01.");
   });
 });

--- a/packages/nextclaw-kernel/src/contributions/context-provider/providers/agent-bootstrap-context.provider.ts
+++ b/packages/nextclaw-kernel/src/contributions/context-provider/providers/agent-bootstrap-context.provider.ts
@@ -121,6 +121,8 @@ export class AgentBootstrapContextProvider implements ContextProvider {
   }): string => {
     const { budget, compactedSession, config, root, sessionKey } = params;
     const parts: string[] = [];
+    // pinned 固定事实：先占预算保证必达，输出时置于文件内容尾部（贴近决策）。
+    const pinnedContent = this.readPinnedFile({ config, root, budget });
     const fileList = this.selectBootstrapFiles(config, sessionKey, compactedSession);
 
     for (const filename of fileList) {
@@ -152,7 +154,37 @@ export class AgentBootstrapContextProvider implements ContextProvider {
       }
     }
 
+    if (pinnedContent) {
+      parts.push(pinnedContent);
+    }
+
     return parts.join("\n\n");
+  };
+
+  private readPinnedFile = (params: {
+    root: string;
+    config: BootstrapContextConfig;
+    budget: BootstrapReadBudget;
+  }): string => {
+    const { budget, config, root } = params;
+    const pinnedFilename = config.pinnedFile?.trim();
+    if (!pinnedFilename) {
+      return "";
+    }
+    const pinnedPath = join(root, pinnedFilename);
+    if (!existsSync(pinnedPath)) {
+      return "";
+    }
+    const raw = readFileSync(pinnedPath, "utf-8").trim();
+    if (!raw || budget.remaining <= 0) {
+      return "";
+    }
+    const pinnedLimit =
+      config.perFileChars > 0 ? config.perFileChars : raw.length;
+    const allowed = Math.min(pinnedLimit, budget.remaining);
+    const content = truncateContextText(raw, allowed);
+    budget.remaining -= content.length;
+    return `## ${pinnedFilename}\n\n${content}`;
   };
 
   private createReadBudget = (

--- a/packages/nextclaw-kernel/src/contributions/context-provider/utils/native-context-config.utils.ts
+++ b/packages/nextclaw-kernel/src/contributions/context-provider/utils/native-context-config.utils.ts
@@ -16,6 +16,7 @@ export const DEFAULT_NATIVE_CONTEXT_CONFIG: ContextConfig = {
     minimalFiles: ["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md"],
     perFileChars: 4000,
     totalChars: 12000,
+    pinnedFile: "pinned.md",
   },
   memory: {
     enabled: true,


### PR DESCRIPTION
由 AI 助手整理（issue #39 之 PR-1，pinned 固定事实层）。

## 背景
agent 上下文缺少"用户固定事实"通道：用户明确置顶、最高优先、不许模型遗忘或反驳的事实（称呼/家庭工作事实/禁忌等）。现有 bootstrap 文件（IDENTITY/SOUL 等）无优先级语义，记忆走独立 memory store。

## 改动
- **core**：`ContextBootstrapSchema` 新增 `pinnedFile`（默认 `pinned.md`），向后兼容，不改 `ContextConfigSchema` 结构；
- **kernel**：`AgentBootstrapContextProvider` 新增 `readPinnedFile`：
  - 先占读取预算（min(perFileChars, remaining)）保证必达，其余 bootstrap 文件共享剩余预算（totalChars 不变量不变）；
  - pinned 块注入 bootstrap 内容**尾部**（贴近模型决策）；
  - 不受会话记忆压缩裁剪（用户固定事实压缩不裁剪）；
  - cron/subagent minimalFiles 场景同样注入；
- **默认值**：`native-context-config.utils` 同步 `pinnedFile: pinned.md`。

## 验证
- provider 单测 3/3 ✓（含 compacted 场景注入、自定义 pinnedFile）
- core config schema 单测 23/23 ✓
- governance all checks passed ✓
- tsc：kernel/core 报错均为 sibling 包未构建的环境缺口（`@nextclaw/core`/`@nextclaw/feishu-core`/`@nextclaw/ncp`），非本次改动引入

## 明确不做（issue #39 其余 PR）
identity 模板化、记忆分层（计划中，后续 PR 跟进）；模板 marketplace 分发/UI 入口（超范围）。