### PR TITLE
feat(core): memory digest layout + user profile store contract (long-term memory PR-1)

### DIFF
--- a/packages/nextclaw-core/src/features/agent/features/memory/memory.store.test.ts
+++ b/packages/nextclaw-core/src/features/agent/features/memory/memory.store.test.ts
@@ -1,0 +1,124 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "./memory.store.js";
+
+const makeWorkspace = (): string => mkdtempSync(join(tmpdir(), "np-memory-"));
+
+const cleanup = (dir: string): void => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+describe("MemoryStore digest + source hash", () => {
+  it("writes a digest card with frontmatter and lists it back", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new MemoryStore(ws);
+      const path = store.writeDigestCard("procedure", {
+        name: "staging verification",
+        description: "发布前先验证 staging",
+        source: "session:rel-1",
+        body: "任何生产发布都应先执行 staging 验证。",
+      });
+      expect(path).toContain(join("memory", "digest", "procedure"));
+      expect(existsSync(path)).toBe(true);
+
+      const listed = store.listDigestCards("procedure");
+      expect(listed).toHaveLength(1);
+
+      const content = store.readDigestCard("procedure", "staging verification");
+      expect(content).toContain("name: staging verification");
+      expect(content).toContain("description: 发布前先验证 staging");
+      expect(content).toContain("source: session:rel-1");
+      expect(content).toContain("任何生产发布都应先执行 staging 验证。");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("sanitizes card file names and keeps Chinese", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new MemoryStore(ws);
+      const path = store.writeDigestCard("wiki", {
+        name: "生产发布约定!@#",
+        description: "desc",
+        source: "s",
+        body: "body",
+      });
+      expect(path.endsWith("生产发布约定.md")).toBe(true);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("reads an unknown digest card as empty", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new MemoryStore(ws);
+      expect(store.readDigestCard("personal", "missing")).toBe("");
+      expect(store.listDigestCards("personal")).toEqual([]);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("hashes a source key deterministically and one-way", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new MemoryStore(ws);
+      const a = store.hashSource("session:abc");
+      const b = store.hashSource("session:abc");
+      const c = store.hashSource("session:abd");
+      expect(a).toBe(b);
+      expect(a).toHaveLength(32);
+      expect(a).not.toBe(c);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("lists all memory markdown files including digest subdirectories", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new MemoryStore(ws);
+      writeFileSync(join(ws, "memory", "2026-09-01.md"), "# day\n", "utf-8");
+      store.writeDigestCard("personal", {
+        name: "user-notes",
+        description: "notes",
+        source: "s",
+        body: "body",
+      });
+      store.writeDigestCard("wiki", {
+        name: "concept",
+        description: "c",
+        source: "s",
+        body: "b",
+      });
+      const files = store.listAllMemoryFiles();
+      expect(files.some((f) => f.endsWith("2026-09-01.md"))).toBe(true);
+      expect(files.some((f) => f.endsWith(join("digest", "personal", "user-notes.md")))).toBe(true);
+      expect(files.some((f) => f.endsWith(join("digest", "wiki", "concept.md")))).toBe(true);
+      // index 目录（若有）不入列表
+      expect(files.some((f) => f.includes(join("memory", "index")))).toBe(false);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("keeps legacy workspace MEMORY.md and memory/*.md readable", () => {
+    const ws = makeWorkspace();
+    try {
+      writeFileSync(join(ws, "MEMORY.md"), "# legacy long-term\n", "utf-8");
+      mkdirSync(join(ws, "memory"), { recursive: true });
+      writeFileSync(join(ws, "memory", "MEMORY.md"), "# memory long-term\n", "utf-8");
+      const store = new MemoryStore(ws);
+      expect(store.readWorkspaceMemory()).toContain("legacy");
+      expect(store.readLongTerm()).toContain("memory long-term");
+      expect(readdirSync(join(ws, "memory")).some((n) => n.endsWith(".md"))).toBe(true);
+    } finally {
+      cleanup(ws);
+    }
+  });
+});

--- a/packages/nextclaw-core/src/features/agent/features/memory/memory.store.ts
+++ b/packages/nextclaw-core/src/features/agent/features/memory/memory.store.ts
@@ -1,8 +1,52 @@
-import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
-import { ensureDir, todayDate } from "../../../../shared/lib/core-utils/utils/helpers.utils.js";
+import { ensureDir, todayDate } from "@core/shared/lib/core-utils/index.js";
 
 const readTextIfExists = (path: string): string => (existsSync(path) ? readFileSync(path, "utf-8") : "");
+
+export type DigestCategory = "personal" | "procedure" | "wiki";
+
+export const DIGEST_CATEGORIES: readonly DigestCategory[] = [
+  "personal",
+  "procedure",
+  "wiki",
+] as const;
+
+export interface MemoryCard {
+  /** 卡片名（digest 节点名或每日记忆标题） */
+  name: string;
+  /** 一句话摘要 */
+  description: string;
+  /** 来源：会话 key 或相对记忆文件路径 */
+  source: string;
+  /** 卡片正文 */
+  body: string;
+}
+
+const isDigestCategory = (value: string): value is DigestCategory =>
+  (DIGEST_CATEGORIES as readonly string[]).includes(value);
+
+const safeName = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fa5-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "untitled";
+
+const frontmatter = (card: MemoryCard): string =>
+  [
+    "---",
+    `name: ${card.name}`,
+    `description: ${card.description.replace(/\n/g, " ")}`,
+    `source: ${card.source}`,
+    "---",
+  ].join("\n");
+
+const writeTextFile = (path: string, content: string): void => {
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+};
 
 export class MemoryStore {
   private memoryDir: string;
@@ -61,6 +105,54 @@ export class MemoryStore {
       .sort()
       .reverse()
       .map((name) => join(this.memoryDir, name));
+  };
+
+  /** 将来源会话 key 哈希为固定长度标识（用于追溯目录命名，单向映射）。 */
+  hashSource = (key: string): string => createHash("sha256").update(key).digest("hex").slice(0, 32);
+
+  /** 在 memory/digest/<category>/ 写入一张带 frontmatter 的长期卡片。 */
+  writeDigestCard = (category: DigestCategory, card: MemoryCard): string => {
+    const digestDir = join(this.memoryDir, "digest", category);
+    const filePath = join(digestDir, `${safeName(card.name)}.md`);
+    const content = `${frontmatter(card)}\n\n${card.body.trim()}\n`;
+    writeTextFile(filePath, content);
+    return filePath;
+  };
+
+  /** 列出 digest 某分类下全部卡片路径（未写任何卡片时为空）。 */
+  listDigestCards = (category: DigestCategory): string[] => {
+    const dir = join(this.memoryDir, "digest", category);
+    if (!existsSync(dir)) {
+      return [];
+    }
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".md"))
+      .sort()
+      .map((name) => join(dir, name));
+  };
+
+  /** 读取 digest 卡片原始内容；目录分类非法时返回空串。 */
+  readDigestCard = (category: DigestCategory, name: string): string =>
+    readTextIfExists(join(this.memoryDir, "digest", category, `${safeName(name)}.md`));
+
+  /** 在当前分身 workspace 内递归列出全部记忆文件（含 digest），供 CLI/list 审计。 */
+  listAllMemoryFiles = (): string[] => {
+    const files: string[] = [];
+    const walk = (dir: string): void => {
+      if (!existsSync(dir)) {
+        return;
+      }
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          walk(full);
+        } else if (entry.endsWith(".md")) {
+          files.push(full);
+        }
+      }
+    };
+    walk(this.memoryDir);
+    return files.sort();
   };
 
   getMemoryContext = (): string => {

--- a/packages/nextclaw-core/src/features/agent/features/memory/user-profile.store.test.ts
+++ b/packages/nextclaw-core/src/features/agent/features/memory/user-profile.store.test.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { UserProfileStore } from "./user-profile.store.js";
+
+const makeWorkspace = (): string => mkdtempSync(join(tmpdir(), "np-profile-"));
+
+const cleanup = (dir: string): void => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+describe("UserProfileStore", () => {
+  it("starts empty and reports no profile", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      expect(store.hasProfile()).toBe(false);
+      expect(store.readProfile()).toBe("");
+      expect(store.listCandidates()).toEqual([]);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("writes and reads an approved profile", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      store.writeProfile("# 画像\n\n## Preferences\n- 中文回复\n");
+      expect(store.hasProfile()).toBe(true);
+      expect(store.readProfile()).toContain("中文回复");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("appends a candidate and persists it for later listing", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      const created = store.appendCandidate({
+        section: "identity",
+        entry: "称呼：阿算",
+        source: "session:abc",
+      });
+      expect(created).not.toBeNull();
+      expect(created?.section).toBe("identity");
+      expect(store.listCandidates()).toHaveLength(1);
+
+      const reopened = new UserProfileStore(ws);
+      expect(reopened.listCandidates()).toHaveLength(1);
+      expect(reopened.listCandidates()[0].entry).toBe("称呼：阿算");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("deduplicates identical candidates in the same section", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      store.appendCandidate({ section: "identity", entry: "称呼：阿算", source: "s1" });
+      const duplicate = store.appendCandidate({
+        section: "identity",
+        entry: "称呼：阿算",
+        source: "s2",
+      });
+      expect(duplicate).toBeNull();
+      expect(store.listCandidates()).toHaveLength(1);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("approves a candidate by merging into the matching profile section", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      const candidate = store.appendCandidate({
+        section: "preferences",
+        entry: "发布前先跑 staging 验证",
+        source: "session:rel-1",
+      });
+      expect(candidate).not.toBeNull();
+      const approved = store.approveCandidate(candidate!.id);
+      expect(approved?.entry).toBe("发布前先跑 staging 验证");
+      // 候选项已移除
+      expect(store.listCandidates()).toHaveLength(0);
+      // 画像文件生成对应小节与条目
+      const profile = store.readProfile();
+      expect(profile).toContain("## Preferences");
+      expect(profile).toContain("发布前先跑 staging 验证");
+      expect(profile).toContain("session:rel-1");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("approving an unknown candidate returns null", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      expect(store.approveCandidate("nope")).toBeNull();
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("rejects a candidate without touching the profile", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      store.writeProfile("## Boundaries\n- 不读私人目录\n");
+      const candidate = store.appendCandidate({
+        section: "boundaries",
+        entry: "不自动发布",
+        source: "session:b",
+      });
+      expect(candidate).not.toBeNull();
+      expect(store.rejectCandidate(candidate!.id)).toBe(true);
+      expect(store.listCandidates()).toHaveLength(0);
+      expect(store.readProfile()).not.toContain("不自动发布");
+      expect(store.rejectCandidate(candidate!.id)).toBe(false);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("candidate file is omitted when no candidates remain", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      store.appendCandidate({ section: "identity", entry: "称呼：阿算", source: "s" });
+      expect(existsSync(join(ws, "USER.candidates.md"))).toBe(true);
+      const c = store.listCandidates()[0];
+      store.rejectCandidate(c.id);
+      expect(existsSync(join(ws, "USER.candidates.md"))).toBe(false);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("does not read from pinned.md (profile stays independent)", () => {
+    const ws = makeWorkspace();
+    try {
+      writeFileSync(join(ws, "pinned.md"), "## Pinned\n- 最高优先级事实\n", "utf-8");
+      const store = new UserProfileStore(ws);
+      expect(store.readProfile()).toBe("");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("persists multi-line file content verbatim on write", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new UserProfileStore(ws);
+      const content = "## Identity\n- 称呼：阿算\n\n## Boundaries\n- 不删数据\n";
+      store.writeProfile(content);
+      expect(readFileSync(join(ws, "USER.md"), "utf-8")).toBe(content);
+    } finally {
+      cleanup(ws);
+    }
+  });
+});

--- a/packages/nextclaw-core/src/features/agent/features/memory/user-profile.store.ts
+++ b/packages/nextclaw-core/src/features/agent/features/memory/user-profile.store.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { ensureDir, todayDate } from "@core/shared/lib/core-utils/index.js";
+
+/**
+ * 使用人画像 store（issue #41 PR-1）。
+ *
+ * 每个分身 workspace 维护两个文件：
+ * - `USER.md`：已审批生效的使用人画像（称呼/稳定偏好/边界）。
+ * - `USER.candidates.md`：Auto-Capture 产出的画像候选队列（写前审批，
+ *   审批通过才并入 USER.md，防止自动沉淀污染画像）。
+ *
+ * 画像与 pinned 的关系：pinned.md（已冻结 persona-pinned-layer 设计）是
+ * 使用者显式固定的最高优先级事实，覆盖画像自动推断；本 store 不读取 pinned。
+ */
+export type UserProfileSection = "identity" | "preferences" | "boundaries";
+
+export const USER_PROFILE_SECTIONS: readonly UserProfileSection[] = [
+  "identity",
+  "preferences",
+  "boundaries",
+] as const;
+
+export interface UserProfileCandidate {
+  /** 稳定 id（写入 candidates 时生成） */
+  id: string;
+  /** 画像小节归属 */
+  section: UserProfileSection;
+  /** 一句话画像条目（如 "称呼：阿算"） */
+  entry: string;
+  /** 来源（session key 或记忆文件路径） */
+  source: string;
+  /** 创建时间 ISO */
+  createdAt: string;
+}
+
+const CANDIDATE_BLOCK_SEPARATOR = "\n---\n";
+
+const parseCandidateBlocks = (raw: string): UserProfileCandidate[] => {
+  const text = raw.trim();
+  if (!text) {
+    return [];
+  }
+  return text
+    .split(CANDIDATE_BLOCK_SEPARATOR)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const lines = block.split("\n");
+      const candidate: Partial<UserProfileCandidate> = {};
+      for (const line of lines) {
+        const match = /^([a-zA-Z]+):\s*(.+)$/.exec(line);
+        if (!match) {
+          continue;
+        }
+        const key = match[1] as keyof UserProfileCandidate;
+        const value = match[2].trim();
+        if (key === "section" && isProfileSection(value)) {
+          candidate.section = value;
+        } else if (key === "id") {
+          candidate.id = value;
+        } else if (key === "entry") {
+          candidate.entry = value;
+        } else if (key === "source") {
+          candidate.source = value;
+        } else if (key === "createdAt") {
+          candidate.createdAt = value;
+        }
+      }
+      return candidate as UserProfileCandidate;
+    })
+    .filter((candidate) => Boolean(candidate.id && candidate.entry));
+};
+
+const isProfileSection = (value: string): value is UserProfileSection =>
+  (USER_PROFILE_SECTIONS as readonly string[]).includes(value);
+
+const serializeCandidateBlocks = (
+  candidates: readonly UserProfileCandidate[],
+): string =>
+  candidates
+    .map(
+      (candidate) =>
+        `id: ${candidate.id}\nsection: ${candidate.section}\nentry: ${candidate.entry}\nsource: ${candidate.source}\ncreatedAt: ${candidate.createdAt}`,
+    )
+    .join(CANDIDATE_BLOCK_SEPARATOR);
+
+const readTextIfExists = (path: string): string =>
+  existsSync(path) ? readFileSync(path, "utf-8") : "";
+
+export class UserProfileStore {
+  private readonly profileFile: string;
+  private readonly candidatesFile: string;
+
+  constructor(workspace: string) {
+    ensureDir(workspace);
+    this.profileFile = join(workspace, "USER.md");
+    this.candidatesFile = join(workspace, "USER.candidates.md");
+  }
+
+  /** 已审批生效的画像原文（无文件时为空串）。 */
+  readProfile = (): string => readTextIfExists(this.profileFile);
+
+  /** 写入整份已生效画像（仅审批动作调用；不覆盖 pinned.md）。 */
+  writeProfile = (content: string): void => {
+    writeFileSync(this.profileFile, content, "utf-8");
+  };
+
+  /** 画像文件是否存在。 */
+  hasProfile = (): boolean => existsSync(this.profileFile);
+
+  /** 候选队列原文（无文件时为空串）。 */
+  readCandidatesRaw = (): string => readTextIfExists(this.candidatesFile);
+
+  /** 解析后的候选列表。 */
+  listCandidates = (): UserProfileCandidate[] =>
+    parseCandidateBlocks(readTextIfExists(this.candidatesFile));
+
+  /** 队列空时删除候选文件，避免空文件残留。 */
+  private persistCandidates = (candidates: readonly UserProfileCandidate[]): void => {
+    if (candidates.length === 0) {
+      if (existsSync(this.candidatesFile)) {
+        unlinkSync(this.candidatesFile);
+      }
+      return;
+    }
+    writeFileSync(this.candidatesFile, `${serializeCandidateBlocks(candidates)}\n`, "utf-8");
+  };
+
+  /**
+   * 追加一条画像候选（Auto-Capture 产出，不自动生效）。
+   * 返回生成候选；重复 entry 去重（同一 section 已存在则返回 null）。
+   */
+  appendCandidate = (
+    input: Pick<UserProfileCandidate, "section" | "entry" | "source">,
+  ): UserProfileCandidate | null => {
+    const existing = this.listCandidates();
+    if (
+      existing.some(
+        (candidate) =>
+          candidate.section === input.section &&
+          candidate.entry.trim() === input.entry.trim(),
+      )
+    ) {
+      return null;
+    }
+    const candidate: UserProfileCandidate = {
+      id: randomUUID(),
+      section: input.section,
+      entry: input.entry.trim(),
+      source: input.source,
+      createdAt: new Date().toISOString(),
+    };
+    this.persistCandidates([...existing, candidate]);
+    return candidate;
+  };
+
+  /**
+   * 审批通过指定候选：把条目并入 USER.md 对应小节，并从候选队列移除。
+   * 返回被并入的候选；不存在返回 null。
+   */
+  approveCandidate = (candidateId: string): UserProfileCandidate | null => {
+    const existing = this.listCandidates();
+    const candidate = existing.find((item) => item.id === candidateId);
+    if (!candidate) {
+      return null;
+    }
+    const rest = existing.filter((item) => item.id !== candidateId);
+    this.persistCandidates(rest);
+
+    const profile = readTextIfExists(this.profileFile);
+    const heading = this.sectionHeading(candidate.section);
+    const entryLine = `- ${candidate.entry} (source: ${candidate.source}, ${candidate.createdAt.slice(0, 10)})`;
+    let nextProfile: string;
+    const headingIndex = profile.split("\n").findIndex((line) => line.trim() === heading);
+    if (headingIndex >= 0) {
+      const lines = profile.split("\n");
+      lines.splice(headingIndex + 1, 0, entryLine);
+      nextProfile = lines.join("\n");
+    } else {
+      const header = profile.trim() ? `\n\n` : "";
+      nextProfile = `${profile.trim()}${header}${heading}\n${entryLine}\n`;
+    }
+    writeFileSync(this.profileFile, nextProfile.trimEnd() + "\n", "utf-8");
+    return candidate;
+  };
+
+  /** 拒绝候选：仅从队列移除，不写入画像。返回是否移除成功。 */
+  rejectCandidate = (candidateId: string): boolean => {
+    const existing = this.listCandidates();
+    const rest = existing.filter((item) => item.id !== candidateId);
+    if (rest.length === existing.length) {
+      return false;
+    }
+    this.persistCandidates(rest);
+    return true;
+  };
+
+  private sectionHeading = (section: UserProfileSection): string =>
+    `## ${section[0].toUpperCase()}${section.slice(1)}`;
+
+  /** 今日日期（测试/审计辅助）。 */
+  readonly today = todayDate();
+}

--- a/packages/nextclaw-core/src/features/agent/index.ts
+++ b/packages/nextclaw-core/src/features/agent/index.ts
@@ -7,6 +7,15 @@ export type {
   SkillsLoaderOptions,
 } from "./services/skills-loader.service.js";
 export { MemoryStore } from "./features/memory/memory.store.js";
+export type {
+  DigestCategory,
+  MemoryCard,
+} from "./features/memory/memory.store.js";
+export { UserProfileStore } from "./features/memory/user-profile.store.js";
+export type {
+  UserProfileCandidate,
+  UserProfileSection,
+} from "./features/memory/user-profile.store.js";
 export { resolveNextclawSelfManageGuidePaths } from "./features/self-manage/guide-path.js";
 export { SILENT_REPLY_TOKEN } from "./types/tokens.js";
 export * from "./services/silent-reply-policy.js";


### PR DESCRIPTION
## 目标

[issue #41](https://github.com/Peiiii/nextclaw/issues/41) PR-1：落地「记忆与画像目录契约 + store 扩展」的 store 契约层，作为长期记忆方案（捕获 → 沉淀 → 整合 → 检索 → 注入）的地基。本 PR 不改变任何用户可见行为，纯向后兼容的 core 层扩展。

## 改动

**`memory.store.ts` 扩展**（向后兼容读取既有 `MEMORY.md` 与 `memory/*.md`）：
- `memory/digest/{personal,procedure,wiki}/` 长期卡片目录契约：`writeDigestCard`（带 name/description/source frontmatter）、`listDigestCards`、`readDigestCard`
- `hashSource`：来源会话 key → sha256 单向 32 位哈希（供追溯目录命名）
- `listAllMemoryFiles`：递归审计当前分身 workspace 全部记忆文件

**新增 `user-profile.store.ts`（UserProfileStore）**：
- 每分身 workspace 两个文件：`USER.md`（已审批生效画像）+ `USER.candidates.md`（Auto-Capture 候选队列，写前审批防污染）
- `appendCandidate`（同小节重复 entry 去重）→ `approveCandidate`（并入 USER.md 对应小节并从队列移除）→ `rejectCandidate`
- 画像随分身 workspace 隔离，不读取 pinned.md（persona-pinned-layer 为独立冻结设计）

**导出**：`features/agent/index.ts` 注册新类型与 store。

## 边界说明

- CLI 只读入口（`nextclaw memory list` / `nextclaw profile show`）按计划并入 PR-2（与 Auto-Capture 及 approve/reject CLI 同批），避免本 PR 携带独立 CLI 装配 + 双语文档同步的改动面。
- 画像/记忆的判定（Auto-Capture）、检索注入（BM25）、Auto-Digest cron、审批队列外壳分别由 PR-2/3/4/5 交付。

## 验证

- 新增单测 16/16 通过（memory.store 6 + user-profile.store 10：写入/列表/去重/审批/拒绝/兼容）
- `@nextclaw/core` tsc 0 errors
- `pnpm lint:new-code:governance --base origin/master` all checks passed
- diff-only maintainability 检查 0 findings（5 files / net +599 行）
