### PR TITLE
feat(core): pet skin directory contract and store (desktop pet PR-A)

### DIFF
--- a/packages/nextclaw-core/src/features/agent/features/pet/configs/default-pets.config.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/configs/default-pets.config.ts
@@ -1,0 +1,17 @@
+import type { PetManifest } from "@core/features/agent/features/pet/types/pet.types.js";
+
+/**
+ * 内置默认皮（桌宠 PR-A）。
+ * 开箱即用的第一只桌宠：纯 emoji 文字形象，无需位图即可运行。
+ */
+export const DEFAULT_PET: PetManifest = {
+  id: "mochi-claw",
+  name: "小爪",
+  description: "一只暖洋洋的爪爪桌宠，陪你查资料、写文件、整理表格。",
+  emoji: "🐾",
+  vibe: "warm",
+  catchphrase: "爪爪到，事办妥。",
+};
+
+/** 默认皮 id（首次使用无皮时的回退目标）。 */
+export const DEFAULT_PET_ID = DEFAULT_PET.id;

--- a/packages/nextclaw-core/src/features/agent/features/pet/index.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/index.ts
@@ -1,0 +1,9 @@
+export { PetDirectoryStore } from "./utils/pet-directory.utils.js";
+export type { PetDirectoryEntry, PetManifest, PetVibe } from "./types/pet.types.js";
+export {
+  hasPetManifest,
+  parsePetManifest,
+  readPetManifest,
+  PET_MANIFEST_FILE_NAME,
+} from "./utils/pet-manifest.utils.js";
+export { DEFAULT_PET, DEFAULT_PET_ID } from "./configs/default-pets.config.js";

--- a/packages/nextclaw-core/src/features/agent/features/pet/pet-directory.utils.test.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/pet-directory.utils.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { PetManifest } from "./types/pet.types.js";
+import { PetDirectoryStore, PETS_DIRECTORY_NAME } from "./utils/pet-directory.utils.js";
+import { PET_MANIFEST_FILE_NAME } from "./utils/pet-manifest.utils.js";
+
+const makeWorkspace = (): string => mkdtempSync(join(tmpdir(), "np-pet-dir-"));
+
+const cleanup = (dir: string): void => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+const mochi: PetManifest = {
+  id: "mochi-claw",
+  name: "小爪",
+  description: "暖洋洋的爪爪桌宠",
+  emoji: "🐾",
+  vibe: "warm",
+  catchphrase: "爪爪到，事办妥。",
+};
+
+const luna: PetManifest = {
+  id: "luna-owl",
+  name: "月羽",
+  description: "安静的夜猫头鹰",
+  emoji: "🦉",
+  vibe: "calm",
+};
+
+describe("PetDirectoryStore", () => {
+  it("starts empty when workspace has no pets directory", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      expect(store.listPets()).toEqual([]);
+      expect(store.getPet("mochi-claw")).toBeNull();
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("writes a pet manifest into pets/<petId>/pet.json", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      const path = store.writePet(mochi);
+      expect(path).toContain(join(PETS_DIRECTORY_NAME, "mochi-claw", PET_MANIFEST_FILE_NAME));
+      expect(store.getPet("mochi-claw")?.name).toBe("小爪");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("lists discovered pets sorted by id", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      store.writePet(mochi);
+      store.writePet(luna);
+      const entries = store.listPets();
+      expect(entries.map((entry) => entry.manifest.id)).toEqual(["luna-owl", "mochi-claw"]);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("skips broken pet directories during discovery but keeps valid ones", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      store.writePet(mochi);
+      // 造一个损坏皮目录（pet.json 非法）
+      const brokenDir = join(ws, PETS_DIRECTORY_NAME, "broken-pet");
+      mkdirSync(brokenDir, { recursive: true });
+      writeFileSync(join(brokenDir, PET_MANIFEST_FILE_NAME), "{not json", "utf-8");
+      const entries = store.listPets();
+      expect(entries.map((entry) => entry.manifest.id)).toEqual(["mochi-claw"]);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("returns null for a broken pet when read directly (caller degrades)", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      const brokenDir = join(ws, PETS_DIRECTORY_NAME, "broken-pet");
+      mkdirSync(brokenDir, { recursive: true });
+      writeFileSync(join(brokenDir, PET_MANIFEST_FILE_NAME), "{not json", "utf-8");
+      expect(store.getPet("broken-pet")).toBeNull();
+    } finally {
+      cleanup(ws);
+    }
+  });
+});

--- a/packages/nextclaw-core/src/features/agent/features/pet/types/pet.types.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/types/pet.types.ts
@@ -1,0 +1,31 @@
+/**
+ * 桌宠皮（Pet Skin）契约类型（issue #41 周边 / 桌宠设计 PR-A）。
+ *
+ * 每只桌宠 = 一个"皮"：分身 workspace 下 `pets/<petId>/pet.json`。
+ * 皮是纯文本/emoji 可表达的拟人化形象，无位图时可降级为文字桌宠。
+ */
+
+export type PetVibe = "warm" | "sharp" | "calm" | "playful" | "chaotic";
+
+export type PetManifest = {
+  /** 皮 id（kebab-case，目录名） */
+  id: string;
+  /** 桌宠名字（如 "小爪"） */
+  name: string;
+  /** 一句话性格/形象描述 */
+  description: string;
+  /** 标志性 emoji（无位图时的文字形象） */
+  emoji: string;
+  /** 性格气质 */
+  vibe: PetVibe;
+  /** 口头禅（可选） */
+  catchphrase?: string;
+  /** 位图/精灵图路径（可选；缺失时降级文字桌宠） */
+  spritePath?: string;
+};
+
+export type PetDirectoryEntry = {
+  /** pet.json 绝对路径 */
+  manifestPath: string;
+  manifest: PetManifest;
+};

--- a/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-directory.utils.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-directory.utils.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PetDirectoryEntry, PetManifest } from "@core/features/agent/features/pet/types/pet.types.js";
+import {
+  hasPetManifest,
+  readPetManifest,
+  PET_MANIFEST_FILE_NAME,
+} from "./pet-manifest.utils.js";
+
+/** 分身 workspace 下皮目录的固定名字（与 memory/ 同级）。 */
+export const PETS_DIRECTORY_NAME = "pets";
+
+/**
+ * 桌宠皮目录 store（桌宠设计 PR-A）。
+ *
+ * 布局：`<分身 workspace>/pets/<petId>/pet.json`。提供列表发现与指定皮读取，
+ * 不承载 UI 状态（激活皮/换皮交互归属 UI feature）；非法/缺失皮由调用方降级。
+ */
+export class PetDirectoryStore {
+  private readonly petsDir: string;
+
+  constructor(private readonly workspace: string) {
+    this.petsDir = join(workspace, PETS_DIRECTORY_NAME);
+  }
+
+  /** pets 目录路径（不存在也会返回路径，读取前用 exists 判断）。 */
+  getPetsDir = (): string => this.petsDir;
+
+  /** 写入或覆盖一个皮（含 manifest 目录与 pet.json）。 */
+  writePet = (manifest: PetManifest): string => {
+    const dir = join(this.petsDir, manifest.id);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, PET_MANIFEST_FILE_NAME);
+    writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+    return path;
+  };
+
+  /** 列出 workspace 内全部有效皮（manifest 缺失/非法的目录跳过）。 */
+  listPets = (): PetDirectoryEntry[] => {
+    if (!existsSync(this.petsDir)) {
+      return [];
+    }
+    const entries: PetDirectoryEntry[] = [];
+    for (const entry of readdirSync(this.petsDir)) {
+      const dir = join(this.petsDir, entry);
+      if (!hasPetManifest(dir)) {
+        continue;
+      }
+      try {
+        entries.push({
+          manifestPath: join(dir, PET_MANIFEST_FILE_NAME),
+          manifest: readPetManifest(dir),
+        });
+      } catch {
+        // 单皮损坏不影响其余皮发现
+      }
+    }
+    return entries.sort((left, right) => left.manifest.id.localeCompare(right.manifest.id));
+  };
+
+  /** 读取指定皮；不存在或损坏返回 null（调用方降级文字桌宠/默认皮）。 */
+  getPet = (petId: string): PetManifest | null => {
+    const dir = join(this.petsDir, petId);
+    if (!hasPetManifest(dir)) {
+      return null;
+    }
+    try {
+      return readPetManifest(dir);
+    } catch {
+      return null;
+    }
+  };
+}

--- a/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.test.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  hasPetManifest,
+  parsePetManifest,
+  readPetManifest,
+  PET_MANIFEST_FILE_NAME,
+} from "./pet-manifest.utils.js";
+
+const makePetDir = (): string => mkdtempSync(join(tmpdir(), "np-pet-manifest-"));
+
+const cleanup = (dir: string): void => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+const validRaw = JSON.stringify({
+  id: "mochi-claw",
+  name: "小爪",
+  description: "暖洋洋的爪爪桌宠",
+  emoji: "🐾",
+  vibe: "warm",
+  catchphrase: "爪爪到，事办妥。",
+});
+
+describe("parsePetManifest", () => {
+  it("parses a valid manifest with defaults", () => {
+    const manifest = parsePetManifest(validRaw);
+    expect(manifest.id).toBe("mochi-claw");
+    expect(manifest.name).toBe("小爪");
+    expect(manifest.emoji).toBe("🐾");
+    expect(manifest.vibe).toBe("warm");
+    expect(manifest.catchphrase).toBe("爪爪到，事办妥。");
+    expect(manifest.spritePath).toBeUndefined();
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => parsePetManifest("{not json")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects non-object payload", () => {
+    expect(() => parsePetManifest('["x"]')).toThrow(/must contain an object/);
+  });
+
+  it("requires kebab-case id", () => {
+    expect(() =>
+      parsePetManifest(JSON.stringify({ ...JSON.parse(validRaw), id: "Bad Id" })),
+    ).toThrow(/kebab-case/);
+  });
+
+  it("rejects unknown vibe", () => {
+    expect(() =>
+      parsePetManifest(JSON.stringify({ ...JSON.parse(validRaw), vibe: "angry" })),
+    ).toThrow(/vibe/);
+  });
+
+  it("defaults missing vibe to warm", () => {
+    const raw = JSON.parse(validRaw) as Record<string, unknown>;
+    delete raw.vibe;
+    expect(parsePetManifest(JSON.stringify(raw)).vibe).toBe("warm");
+  });
+});
+
+describe("readPetManifest / hasPetManifest", () => {
+  it("reads pet.json from a pet directory", () => {
+    const dir = makePetDir();
+    try {
+      writeFileSync(join(dir, PET_MANIFEST_FILE_NAME), validRaw, "utf-8");
+      expect(hasPetManifest(dir)).toBe(true);
+      expect(readPetManifest(dir).id).toBe("mochi-claw");
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("reports false when pet.json is missing", () => {
+    const dir = makePetDir();
+    try {
+      expect(hasPetManifest(dir)).toBe(false);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});

--- a/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.ts
@@ -1,0 +1,68 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import type { PetManifest, PetVibe } from "@core/features/agent/features/pet/types/pet.types.js";
+
+/** 皮清单文件名契约（与 panel-app.json / service-app.json 同族）。 */
+export const PET_MANIFEST_FILE_NAME = "pet.json";
+
+const PET_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const PET_VIBES = new Set<PetVibe>(["warm", "sharp", "calm", "playful", "chaotic"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+const readRequiredString = (record: Record<string, unknown>, key: string): string => {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`pet.json is missing required string field '${key}'.`);
+  }
+  return value.trim();
+};
+
+const readOptionalString = (record: Record<string, unknown>, key: string): string | undefined => {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+};
+
+export function parsePetManifest(raw: string): PetManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `pet.json is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("pet.json must contain an object.");
+  }
+
+  const id = readRequiredString(parsed, "id");
+  if (!PET_ID_PATTERN.test(id)) {
+    throw new Error("pet id must be kebab-case.");
+  }
+  const vibe = readOptionalString(parsed, "vibe") ?? "warm";
+  if (!PET_VIBES.has(vibe as PetVibe)) {
+    throw new Error("pet vibe must be one of warm|sharp|calm|playful|chaotic.");
+  }
+
+  return {
+    id,
+    name: readRequiredString(parsed, "name"),
+    description: readRequiredString(parsed, "description"),
+    emoji: readRequiredString(parsed, "emoji"),
+    vibe: vibe as PetVibe,
+    catchphrase: readOptionalString(parsed, "catchphrase"),
+    spritePath: readOptionalString(parsed, "spritePath"),
+  };
+}
+
+/** 读取某皮目录下的 pet.json（缺失/非法抛错，由调用方决定降级）。 */
+export function readPetManifest(petDirPath: string): PetManifest {
+  return parsePetManifest(readFileSync(join(petDirPath, PET_MANIFEST_FILE_NAME), "utf-8"));
+}
+
+/** 皮目录是否含 pet.json。 */
+export function hasPetManifest(petDirPath: string): boolean {
+  return existsSync(join(petDirPath, PET_MANIFEST_FILE_NAME));
+}


### PR DESCRIPTION
## 目标

按桌宠设计（docs/designs/2026-09-05-desktop-pet.design.md，拟人化贯穿体验主线）落地 PR-A：core 皮契约层。桌宠皮（Pet Skin）= 分身 workspace `pets/<petId>/pet.json`，与 panel-app.json / service-app.json 同族的目录发现契约。本 PR 为契约先行（同长期记忆 PR-1 模式），无 UI/agent 依赖。

## 改动（@nextclaw/core，全部新增）

**皮清单契约（`pet-manifest.utils.ts` + `types/pet.types.ts`）**
- `pet.json` 字段：id（kebab-case）/ name / description / emoji / vibe / catchphrase（可选）/ spritePath（可选，缺失时降级文字桌宠）
- 校验齐全：非法 JSON、非对象、缺必填字符串、id 非 kebab-case、vibe 越界（warm|sharp|calm|playful|chaotic）均抛明确错误
- `readPetManifest` / `hasPetManifest`

**皮目录 store（`pet-directory.utils.ts`）**
- 布局：`<分身 workspace>/pets/<petId>/pet.json`（与 memory/ 同级，随分身隔离）
- `writePet`：写入/覆盖皮（AI 生成皮的落盘入口）
- `listPets`：列表发现，损坏皮目录跳过不阻断
- `getPet`：直接读取，不存在或损坏返回 null → 调用方降级

**默认皮（`default-pets.config.ts`）**
- 内置 "小爪"（🐾 纯 emoji 文字形象，无位图即可运行），`DEFAULT_PET_ID` 供首次无皮回退

**feature 导出（`index.ts`）**

## 降级链路

`getPet` 返回 null → 回退 `DEFAULT_PET`（纯 emoji 文字桌宠），与设计"AI 生成失败保持文字桌宠"一致。

## 边界

- AI 生成判定与 UI 换皮入口按设计文档 PR 拆分归属 **PR-B**（桌宠组件：可拖可收 + 状态动画 + 气泡），不在本 PR
- 未改 agent-chat-ui / nextclaw-ui / server 任何现有文件

## 验证

- planned-path preflight：5 路径 file roles + module structure 均通过
- 单测 13/13（manifest 契约 8 + 目录 store 5：写入/发现/损坏跳过/降级 null）
- core tsc 0 errors
- `pnpm lint:new-code:governance --base origin/master` all checks passed
- diff-only maintainability 0 findings（7 files / net +387 行）
