### PR TITLE
feat(ui): draggable pet dock floating component (desktop pet PR-B)

### DIFF
--- a/packages/nextclaw-core/src/features/agent/features/pet/configs/default-pets.config.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/configs/default-pets.config.ts
@@ -1,0 +1,17 @@
+import type { PetManifest } from "@core/features/agent/features/pet/types/pet.types.js";
+
+/**
+ * 内置默认皮（桌宠 PR-A）。
+ * 开箱即用的第一只桌宠：纯 emoji 文字形象，无需位图即可运行。
+ */
+export const DEFAULT_PET: PetManifest = {
+  id: "mochi-claw",
+  name: "小爪",
+  description: "一只暖洋洋的爪爪桌宠，陪你查资料、写文件、整理表格。",
+  emoji: "🐾",
+  vibe: "warm",
+  catchphrase: "爪爪到，事办妥。",
+};
+
+/** 默认皮 id（首次使用无皮时的回退目标）。 */
+export const DEFAULT_PET_ID = DEFAULT_PET.id;

--- a/packages/nextclaw-core/src/features/agent/features/pet/index.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/index.ts
@@ -1,0 +1,9 @@
+export { PetDirectoryStore } from "./utils/pet-directory.utils.js";
+export type { PetDirectoryEntry, PetManifest, PetVibe } from "./types/pet.types.js";
+export {
+  hasPetManifest,
+  parsePetManifest,
+  readPetManifest,
+  PET_MANIFEST_FILE_NAME,
+} from "./utils/pet-manifest.utils.js";
+export { DEFAULT_PET, DEFAULT_PET_ID } from "./configs/default-pets.config.js";

--- a/packages/nextclaw-core/src/features/agent/features/pet/pet-directory.utils.test.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/pet-directory.utils.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { PetManifest } from "./types/pet.types.js";
+import { PetDirectoryStore, PETS_DIRECTORY_NAME } from "./utils/pet-directory.utils.js";
+import { PET_MANIFEST_FILE_NAME } from "./utils/pet-manifest.utils.js";
+
+const makeWorkspace = (): string => mkdtempSync(join(tmpdir(), "np-pet-dir-"));
+
+const cleanup = (dir: string): void => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+const mochi: PetManifest = {
+  id: "mochi-claw",
+  name: "小爪",
+  description: "暖洋洋的爪爪桌宠",
+  emoji: "🐾",
+  vibe: "warm",
+  catchphrase: "爪爪到，事办妥。",
+};
+
+const luna: PetManifest = {
+  id: "luna-owl",
+  name: "月羽",
+  description: "安静的夜猫头鹰",
+  emoji: "🦉",
+  vibe: "calm",
+};
+
+describe("PetDirectoryStore", () => {
+  it("starts empty when workspace has no pets directory", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      expect(store.listPets()).toEqual([]);
+      expect(store.getPet("mochi-claw")).toBeNull();
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("writes a pet manifest into pets/<petId>/pet.json", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      const path = store.writePet(mochi);
+      expect(path).toContain(join(PETS_DIRECTORY_NAME, "mochi-claw", PET_MANIFEST_FILE_NAME));
+      expect(store.getPet("mochi-claw")?.name).toBe("小爪");
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("lists discovered pets sorted by id", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      store.writePet(mochi);
+      store.writePet(luna);
+      const entries = store.listPets();
+      expect(entries.map((entry) => entry.manifest.id)).toEqual(["luna-owl", "mochi-claw"]);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("skips broken pet directories during discovery but keeps valid ones", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      store.writePet(mochi);
+      // 造一个损坏皮目录（pet.json 非法）
+      const brokenDir = join(ws, PETS_DIRECTORY_NAME, "broken-pet");
+      mkdirSync(brokenDir, { recursive: true });
+      writeFileSync(join(brokenDir, PET_MANIFEST_FILE_NAME), "{not json", "utf-8");
+      const entries = store.listPets();
+      expect(entries.map((entry) => entry.manifest.id)).toEqual(["mochi-claw"]);
+    } finally {
+      cleanup(ws);
+    }
+  });
+
+  it("returns null for a broken pet when read directly (caller degrades)", () => {
+    const ws = makeWorkspace();
+    try {
+      const store = new PetDirectoryStore(ws);
+      const brokenDir = join(ws, PETS_DIRECTORY_NAME, "broken-pet");
+      mkdirSync(brokenDir, { recursive: true });
+      writeFileSync(join(brokenDir, PET_MANIFEST_FILE_NAME), "{not json", "utf-8");
+      expect(store.getPet("broken-pet")).toBeNull();
+    } finally {
+      cleanup(ws);
+    }
+  });
+});

--- a/packages/nextclaw-core/src/features/agent/features/pet/types/pet.types.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/types/pet.types.ts
@@ -1,0 +1,31 @@
+/**
+ * 桌宠皮（Pet Skin）契约类型（issue #41 周边 / 桌宠设计 PR-A）。
+ *
+ * 每只桌宠 = 一个"皮"：分身 workspace 下 `pets/<petId>/pet.json`。
+ * 皮是纯文本/emoji 可表达的拟人化形象，无位图时可降级为文字桌宠。
+ */
+
+export type PetVibe = "warm" | "sharp" | "calm" | "playful" | "chaotic";
+
+export type PetManifest = {
+  /** 皮 id（kebab-case，目录名） */
+  id: string;
+  /** 桌宠名字（如 "小爪"） */
+  name: string;
+  /** 一句话性格/形象描述 */
+  description: string;
+  /** 标志性 emoji（无位图时的文字形象） */
+  emoji: string;
+  /** 性格气质 */
+  vibe: PetVibe;
+  /** 口头禅（可选） */
+  catchphrase?: string;
+  /** 位图/精灵图路径（可选；缺失时降级文字桌宠） */
+  spritePath?: string;
+};
+
+export type PetDirectoryEntry = {
+  /** pet.json 绝对路径 */
+  manifestPath: string;
+  manifest: PetManifest;
+};

--- a/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-directory.utils.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-directory.utils.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PetDirectoryEntry, PetManifest } from "@core/features/agent/features/pet/types/pet.types.js";
+import {
+  hasPetManifest,
+  readPetManifest,
+  PET_MANIFEST_FILE_NAME,
+} from "./pet-manifest.utils.js";
+
+/** 分身 workspace 下皮目录的固定名字（与 memory/ 同级）。 */
+export const PETS_DIRECTORY_NAME = "pets";
+
+/**
+ * 桌宠皮目录 store（桌宠设计 PR-A）。
+ *
+ * 布局：`<分身 workspace>/pets/<petId>/pet.json`。提供列表发现与指定皮读取，
+ * 不承载 UI 状态（激活皮/换皮交互归属 UI feature）；非法/缺失皮由调用方降级。
+ */
+export class PetDirectoryStore {
+  private readonly petsDir: string;
+
+  constructor(private readonly workspace: string) {
+    this.petsDir = join(workspace, PETS_DIRECTORY_NAME);
+  }
+
+  /** pets 目录路径（不存在也会返回路径，读取前用 exists 判断）。 */
+  getPetsDir = (): string => this.petsDir;
+
+  /** 写入或覆盖一个皮（含 manifest 目录与 pet.json）。 */
+  writePet = (manifest: PetManifest): string => {
+    const dir = join(this.petsDir, manifest.id);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, PET_MANIFEST_FILE_NAME);
+    writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+    return path;
+  };
+
+  /** 列出 workspace 内全部有效皮（manifest 缺失/非法的目录跳过）。 */
+  listPets = (): PetDirectoryEntry[] => {
+    if (!existsSync(this.petsDir)) {
+      return [];
+    }
+    const entries: PetDirectoryEntry[] = [];
+    for (const entry of readdirSync(this.petsDir)) {
+      const dir = join(this.petsDir, entry);
+      if (!hasPetManifest(dir)) {
+        continue;
+      }
+      try {
+        entries.push({
+          manifestPath: join(dir, PET_MANIFEST_FILE_NAME),
+          manifest: readPetManifest(dir),
+        });
+      } catch {
+        // 单皮损坏不影响其余皮发现
+      }
+    }
+    return entries.sort((left, right) => left.manifest.id.localeCompare(right.manifest.id));
+  };
+
+  /** 读取指定皮；不存在或损坏返回 null（调用方降级文字桌宠/默认皮）。 */
+  getPet = (petId: string): PetManifest | null => {
+    const dir = join(this.petsDir, petId);
+    if (!hasPetManifest(dir)) {
+      return null;
+    }
+    try {
+      return readPetManifest(dir);
+    } catch {
+      return null;
+    }
+  };
+}

--- a/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.test.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  hasPetManifest,
+  parsePetManifest,
+  readPetManifest,
+  PET_MANIFEST_FILE_NAME,
+} from "./pet-manifest.utils.js";
+
+const makePetDir = (): string => mkdtempSync(join(tmpdir(), "np-pet-manifest-"));
+
+const cleanup = (dir: string): void => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+const validRaw = JSON.stringify({
+  id: "mochi-claw",
+  name: "小爪",
+  description: "暖洋洋的爪爪桌宠",
+  emoji: "🐾",
+  vibe: "warm",
+  catchphrase: "爪爪到，事办妥。",
+});
+
+describe("parsePetManifest", () => {
+  it("parses a valid manifest with defaults", () => {
+    const manifest = parsePetManifest(validRaw);
+    expect(manifest.id).toBe("mochi-claw");
+    expect(manifest.name).toBe("小爪");
+    expect(manifest.emoji).toBe("🐾");
+    expect(manifest.vibe).toBe("warm");
+    expect(manifest.catchphrase).toBe("爪爪到，事办妥。");
+    expect(manifest.spritePath).toBeUndefined();
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => parsePetManifest("{not json")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects non-object payload", () => {
+    expect(() => parsePetManifest('["x"]')).toThrow(/must contain an object/);
+  });
+
+  it("requires kebab-case id", () => {
+    expect(() =>
+      parsePetManifest(JSON.stringify({ ...JSON.parse(validRaw), id: "Bad Id" })),
+    ).toThrow(/kebab-case/);
+  });
+
+  it("rejects unknown vibe", () => {
+    expect(() =>
+      parsePetManifest(JSON.stringify({ ...JSON.parse(validRaw), vibe: "angry" })),
+    ).toThrow(/vibe/);
+  });
+
+  it("defaults missing vibe to warm", () => {
+    const raw = JSON.parse(validRaw) as Record<string, unknown>;
+    delete raw.vibe;
+    expect(parsePetManifest(JSON.stringify(raw)).vibe).toBe("warm");
+  });
+});
+
+describe("readPetManifest / hasPetManifest", () => {
+  it("reads pet.json from a pet directory", () => {
+    const dir = makePetDir();
+    try {
+      writeFileSync(join(dir, PET_MANIFEST_FILE_NAME), validRaw, "utf-8");
+      expect(hasPetManifest(dir)).toBe(true);
+      expect(readPetManifest(dir).id).toBe("mochi-claw");
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("reports false when pet.json is missing", () => {
+    const dir = makePetDir();
+    try {
+      expect(hasPetManifest(dir)).toBe(false);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});

--- a/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.ts
+++ b/packages/nextclaw-core/src/features/agent/features/pet/utils/pet-manifest.utils.ts
@@ -1,0 +1,68 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import type { PetManifest, PetVibe } from "@core/features/agent/features/pet/types/pet.types.js";
+
+/** 皮清单文件名契约（与 panel-app.json / service-app.json 同族）。 */
+export const PET_MANIFEST_FILE_NAME = "pet.json";
+
+const PET_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const PET_VIBES = new Set<PetVibe>(["warm", "sharp", "calm", "playful", "chaotic"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+const readRequiredString = (record: Record<string, unknown>, key: string): string => {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`pet.json is missing required string field '${key}'.`);
+  }
+  return value.trim();
+};
+
+const readOptionalString = (record: Record<string, unknown>, key: string): string | undefined => {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+};
+
+export function parsePetManifest(raw: string): PetManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `pet.json is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("pet.json must contain an object.");
+  }
+
+  const id = readRequiredString(parsed, "id");
+  if (!PET_ID_PATTERN.test(id)) {
+    throw new Error("pet id must be kebab-case.");
+  }
+  const vibe = readOptionalString(parsed, "vibe") ?? "warm";
+  if (!PET_VIBES.has(vibe as PetVibe)) {
+    throw new Error("pet vibe must be one of warm|sharp|calm|playful|chaotic.");
+  }
+
+  return {
+    id,
+    name: readRequiredString(parsed, "name"),
+    description: readRequiredString(parsed, "description"),
+    emoji: readRequiredString(parsed, "emoji"),
+    vibe: vibe as PetVibe,
+    catchphrase: readOptionalString(parsed, "catchphrase"),
+    spritePath: readOptionalString(parsed, "spritePath"),
+  };
+}
+
+/** 读取某皮目录下的 pet.json（缺失/非法抛错，由调用方决定降级）。 */
+export function readPetManifest(petDirPath: string): PetManifest {
+  return parsePetManifest(readFileSync(join(petDirPath, PET_MANIFEST_FILE_NAME), "utf-8"));
+}
+
+/** 皮目录是否含 pet.json。 */
+export function hasPetManifest(petDirPath: string): boolean {
+  return existsSync(join(petDirPath, PET_MANIFEST_FILE_NAME));
+}

--- a/packages/nextclaw-ui/src/features/pet/components/__tests__/pet-dock.test.tsx
+++ b/packages/nextclaw-ui/src/features/pet/components/__tests__/pet-dock.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PetDock } from '@/features/pet/components/pet-dock';
+import { PetSprite } from '@/features/pet/components/pet-sprite';
+import { usePetDockStore } from '@/features/pet/stores/pet-dock.store';
+import { DEFAULT_PET_VIEW } from '@/features/pet/utils/pet-dock-view.utils';
+import type { PetDockView } from '@/features/pet/types/pet-view.types';
+
+const idleView: PetDockView = { ...DEFAULT_PET_VIEW, expanded: false };
+
+describe('PetSprite', () => {
+  it('renders the pet emoji with accessible label', () => {
+    const { container } = render(<PetSprite view={idleView} />);
+    expect(screen.getByRole('img', { name: '小爪' }).textContent).toContain('🐾');
+    expect(container.querySelector('.pet-sprite')).not.toBeNull();
+  });
+});
+
+describe('PetDock', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // zustand store 是模块级单例，重置到默认避免跨用例污染
+    usePetDockStore.setState({ expanded: false, xPercent: 92, yPercent: 84 });
+  });
+
+  it('renders a collapsed dock button with pet emoji', () => {
+    render(<PetDock view={idleView} />);
+    const button = screen.getByRole('button', { name: /小爪/ });
+    expect(button.textContent).toContain('🐾');
+  });
+
+  it('expands a bubble showing pet identity when clicked', () => {
+    render(<PetDock view={idleView} />);
+    fireEvent.click(screen.getByRole('button', { name: /小爪/ }));
+    expect(screen.getByText('一只暖洋洋的爪爪桌宠，陪你查资料、写文件、整理表格。')).not.toBeNull();
+    // catchphrase 渲染时带中文引号
+    expect(screen.getByText('“爪爪到，事办妥。”')).not.toBeNull();
+  });
+
+  it('renders the new-pet entry only when the host injects onRequestNewPet', () => {
+    const onRequestNewPet = vi.fn();
+    render(<PetDock view={idleView} onRequestNewPet={onRequestNewPet} />);
+    fireEvent.click(screen.getByRole('button', { name: /小爪/ }));
+    fireEvent.click(screen.getByRole('button', { name: '换个形象' }));
+    expect(onRequestNewPet).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the new-pet entry hidden when no host callback is provided', () => {
+    render(<PetDock view={idleView} />);
+    fireEvent.click(screen.getByRole('button', { name: /小爪/ }));
+    expect(screen.queryByRole('button', { name: '换个形象' })).toBeNull();
+  });
+});

--- a/packages/nextclaw-ui/src/features/pet/components/pet-dock.tsx
+++ b/packages/nextclaw-ui/src/features/pet/components/pet-dock.tsx
@@ -1,0 +1,141 @@
+import { memo, useCallback, useRef } from 'react';
+import { usePetDockStore } from '@/features/pet/stores/pet-dock.store';
+import type { PetDockView } from '@/features/pet/types/pet-view.types';
+import { PetSprite } from '@/features/pet/components/pet-sprite';
+import { buildPetDockLabel } from '@/features/pet/utils/pet-dock-view.utils';
+
+type PetDockProps = {
+  view: PetDockView;
+  /** 点桌宠/气泡里"去对话"的跳转（由宿主注入，避免与导航耦合） */
+  onGoToChat?: () => void;
+  /** "换个形象"入口：宿主接入 AI 生成皮链路后注入；未注入时不渲染该按钮 */
+  onRequestNewPet?: () => void;
+};
+
+/**
+ * 右下角可拖可收桌宠浮层：
+ * - 默认折叠为小图标（右上角入口可见）
+ * - 点击展开气泡：名字/一句话性格 + 交互按钮（生成新形象 / 去对话）
+ * - 按住可拖动（百分比定位，持久化到 localStorage）
+ */
+export const PetDock = memo(function PetDock({
+  view,
+  onGoToChat,
+  onRequestNewPet,
+}: PetDockProps) {
+  const expanded = usePetDockStore((state) => state.expanded);
+  const setExpanded = usePetDockStore((state) => state.setExpanded);
+  const xPercent = usePetDockStore((state) => state.xPercent);
+  const yPercent = usePetDockStore((state) => state.yPercent);
+  const moveTo = usePetDockStore((state) => state.moveTo);
+  const dragStateRef = useRef<{ offsetX: number; offsetY: number } | null>(null);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent) => {
+    // 点击交互（气泡/按钮）不触发拖动
+    if ((event.target as HTMLElement).closest('[data-pet-action]')) {
+      return;
+    }
+    dragStateRef.current = { offsetX: event.clientX, offsetY: event.clientY };
+  }, []);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent) => {
+    const start = dragStateRef.current;
+    if (!start) {
+      return;
+    }
+    const dx = event.clientX - start.offsetX;
+    const dy = event.clientY - start.offsetY;
+    if (Math.abs(dx) < 4 && Math.abs(dy) < 4) {
+      return;
+    }
+    const nextX = Math.min(96, Math.max(2, xPercent + (dx / window.innerWidth) * 100));
+    const nextY = Math.min(92, Math.max(4, yPercent + (dy / window.innerHeight) * 100));
+    moveTo(nextX, nextY);
+    dragStateRef.current = { offsetX: event.clientX, offsetY: event.clientY };
+  }, [moveTo, xPercent, yPercent]);
+
+  const handlePointerUp = useCallback(() => {
+    dragStateRef.current = null;
+  }, []);
+
+  const toggleExpanded = useCallback(() => setExpanded(!expanded), [expanded, setExpanded]);
+
+  const pet = view.pet;
+  const label = buildPetDockLabel(view);
+
+  return (
+    <div
+      className="pet-dock fixed z-50 flex flex-col items-end gap-2"
+      style={{ left: `${xPercent}%`, top: `${yPercent}%` }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerUp}
+    >
+      {expanded && pet ? (
+        <div className="pet-dock__bubble w-64 rounded-xl border border-border bg-background p-3 shadow-lg">
+          <div className="flex items-center gap-2">
+            <PetSprite view={view} size="sm" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{pet.name}</p>
+              <p className="truncate text-xs text-muted-foreground">{pet.emoji} {pet.vibe}</p>
+            </div>
+          </div>
+          <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">{pet.description}</p>
+          {pet.catchphrase ? (
+            <p className="mt-1 text-xs italic">“{pet.catchphrase}”</p>
+          ) : null}
+          <div className="mt-3 flex justify-end gap-2">
+            {onRequestNewPet ? (
+              <button
+                type="button"
+                data-pet-action
+                className="text-xs text-muted-foreground hover:text-foreground"
+                onClick={onRequestNewPet}
+              >
+                换个形象
+              </button>
+            ) : null}
+            <button
+              type="button"
+              data-pet-action
+              className="text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setExpanded(false)}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        data-pet-action
+        className="pet-dock__button flex h-12 items-center gap-1 rounded-full border border-border bg-background px-3 shadow-md transition hover:shadow-lg"
+        onClick={toggleExpanded}
+        aria-expanded={expanded}
+        aria-label={label}
+        title={label}
+      >
+        <PetSprite view={view} size="sm" />
+      </button>
+      <div className="flex gap-1" data-pet-action>
+        <button
+          type="button"
+          className="rounded-full border border-border bg-background px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
+          onClick={() => setExpanded(false)}
+        >
+          收起
+        </button>
+        {onGoToChat ? (
+          <button
+            type="button"
+            className="rounded-full border border-border bg-background px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
+            onClick={onGoToChat}
+          >
+            去对话
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+});

--- a/packages/nextclaw-ui/src/features/pet/components/pet-dock.tsx
+++ b/packages/nextclaw-ui/src/features/pet/components/pet-dock.tsx
@@ -73,7 +73,7 @@ export const PetDock = memo(function PetDock({
       onPointerLeave={handlePointerUp}
     >
       {expanded && pet ? (
-        <div className="pet-dock__bubble w-64 rounded-xl border border-border bg-background p-3 shadow-lg">
+        <div className="pet-dock__bubble w-64 rounded-xl border border-border bg-background p-3 shadow-lg animate-in fade-in slide-in-from-bottom-2 duration-200">
           <div className="flex items-center gap-2">
             <PetSprite view={view} size="sm" />
             <div className="min-w-0">
@@ -110,7 +110,7 @@ export const PetDock = memo(function PetDock({
       <button
         type="button"
         data-pet-action
-        className="pet-dock__button flex h-12 items-center gap-1 rounded-full border border-border bg-background px-3 shadow-md transition hover:shadow-lg"
+        className="pet-dock__button flex h-12 items-center gap-1 rounded-full border border-border bg-background px-3 shadow-md transition duration-200 hover:shadow-xl cursor-pointer"
         onClick={toggleExpanded}
         aria-expanded={expanded}
         aria-label={label}

--- a/packages/nextclaw-ui/src/features/pet/components/pet-sprite.tsx
+++ b/packages/nextclaw-ui/src/features/pet/components/pet-sprite.tsx
@@ -1,0 +1,26 @@
+import { memo } from 'react';
+import type { PetDockView } from '@/features/pet/types/pet-view.types';
+
+type PetSpriteProps = {
+  view: PetDockView;
+  size?: 'sm' | 'md';
+};
+
+/** 桌宠形象：纯 emoji 文字形象（无位图依赖），按状态轻微摆动。 */
+export const PetSprite = memo(function PetSprite({ view, size = 'md' }: PetSpriteProps) {
+  const { emoji = '🐾' } = view.pet ?? {};
+  const frameClass =
+    view.state === 'working'
+      ? 'pet-sprite pet-sprite--working'
+      : 'pet-sprite';
+  const sizeClass = size === 'sm' ? 'text-2xl' : 'text-4xl';
+  return (
+    <span
+      className={`${frameClass} ${sizeClass} inline-flex select-none`}
+      role="img"
+      aria-label={view.pet?.name ?? '桌宠'}
+    >
+      {emoji}
+    </span>
+  );
+});

--- a/packages/nextclaw-ui/src/features/pet/index.ts
+++ b/packages/nextclaw-ui/src/features/pet/index.ts
@@ -1,0 +1,5 @@
+export { PetDock } from "./components/pet-dock.js";
+export { PetSprite } from "./components/pet-sprite.js";
+export { usePetDockStore } from "./stores/pet-dock.store.js";
+export type { PetDockLayoutPreferences, PetDockView } from "./types/pet-view.types.js";
+export { DEFAULT_PET_VIEW, buildPetDockLabel } from "./utils/pet-dock-view.utils.js";

--- a/packages/nextclaw-ui/src/features/pet/stores/__tests__/pet-dock.store.test.ts
+++ b/packages/nextclaw-ui/src/features/pet/stores/__tests__/pet-dock.store.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  mergePetDockPersistedLayout,
+  usePetDockStore,
+} from '@/features/pet/stores/pet-dock.store';
+import type { PetDockLayoutPreferences } from '@/features/pet/types/pet-view.types';
+
+const defaultLayout: PetDockLayoutPreferences = {
+  expanded: false,
+  xPercent: 92,
+  yPercent: 84,
+};
+
+describe('mergePetDockPersistedLayout', () => {
+  it('applies valid persisted values', () => {
+    const merged = mergePetDockPersistedLayout(
+      { expanded: true, xPercent: 40, yPercent: 60 },
+      defaultLayout,
+    );
+    expect(merged).toEqual({ expanded: true, xPercent: 40, yPercent: 60 });
+  });
+
+  it('ignores invalid persisted layout values on merge', () => {
+    const merged = mergePetDockPersistedLayout(
+      { expanded: 'yes', xPercent: 'bad', yPercent: 130 },
+      defaultLayout,
+    );
+    expect(merged).toEqual({ expanded: false, xPercent: 92, yPercent: 84 });
+  });
+
+  it('falls back to current layout when persisted payload is not an object', () => {
+    expect(mergePetDockPersistedLayout(null, defaultLayout)).toEqual(defaultLayout);
+  });
+});
+
+describe('usePetDockStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    usePetDockStore.setState(defaultLayout);
+  });
+
+  it('starts collapsed at the default dock position', () => {
+    const { result } = renderHook(() => usePetDockStore());
+    expect(result.current.expanded).toBe(false);
+    expect(result.current.xPercent).toBe(92);
+    expect(result.current.yPercent).toBe(84);
+  });
+
+  it('toggles expanded', () => {
+    const { result } = renderHook(() => usePetDockStore());
+    act(() => result.current.setExpanded(true));
+    expect(result.current.expanded).toBe(true);
+    act(() => result.current.setExpanded(false));
+    expect(result.current.expanded).toBe(false);
+  });
+
+  it('persists position after move', () => {
+    const { result } = renderHook(() => usePetDockStore());
+    act(() => result.current.moveTo(50, 40));
+    expect(result.current.xPercent).toBe(50);
+    expect(result.current.yPercent).toBe(40);
+  });
+});

--- a/packages/nextclaw-ui/src/features/pet/stores/pet-dock.store.ts
+++ b/packages/nextclaw-ui/src/features/pet/stores/pet-dock.store.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import type { PetDockLayoutPreferences } from '@/features/pet/types/pet-view.types';
+
+const PET_DOCK_STORAGE_KEY = 'nextclaw.pet-dock.state';
+const PET_DOCK_STORAGE_VERSION = 1;
+
+type PetDockStore = PetDockLayoutPreferences & {
+  setExpanded: (expanded: boolean) => void;
+  moveTo: (xPercent: number, yPercent: number) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
+function readPercent(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  // 越界持久化值视为异常数据，回退默认位置而非 clamp
+  return value < 0 || value > 100 ? fallback : value;
+}
+
+type PetDockPersistedLayout = {
+  expanded?: unknown;
+  xPercent?: unknown;
+  yPercent?: unknown;
+};
+
+/** 合并持久化布局（纯函数，单测可直接验证）。泛型保留 currentState 的完整结构（含 actions）。 */
+export function mergePetDockPersistedLayout<S extends PetDockLayoutPreferences>(
+  persistedState: unknown,
+  currentState: S,
+): S {
+  if (!isRecord(persistedState)) {
+    return currentState;
+  }
+  return {
+    ...currentState,
+    expanded:
+      typeof persistedState.expanded === 'boolean'
+        ? persistedState.expanded
+        : false,
+    xPercent: readPercent(persistedState.xPercent, currentState.xPercent),
+    yPercent: readPercent(persistedState.yPercent, currentState.yPercent),
+  };
+}
+
+export const usePetDockStore = create<PetDockStore>()(
+  persist(
+    (set) => ({
+      expanded: false,
+      xPercent: 92,
+      yPercent: 84,
+      setExpanded: (expanded) => set({ expanded }),
+      moveTo: (xPercent, yPercent) => set({ xPercent, yPercent }),
+    }),
+    {
+      name: PET_DOCK_STORAGE_KEY,
+      version: PET_DOCK_STORAGE_VERSION,
+      storage: createJSONStorage(() => window.localStorage),
+      partialize: (state) => ({
+        expanded: state.expanded,
+        xPercent: state.xPercent,
+        yPercent: state.yPercent,
+      }),
+      merge: (persistedState, currentState) =>
+        mergePetDockPersistedLayout(persistedState, currentState),
+    },
+  ),
+);

--- a/packages/nextclaw-ui/src/features/pet/types/pet-view.types.ts
+++ b/packages/nextclaw-ui/src/features/pet/types/pet-view.types.ts
@@ -1,0 +1,26 @@
+/** UI 视图层皮结构（独立于 core 契约，UI 不直接依赖 @nextclaw/core）。 */
+export type PetDockPetView = {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  vibe: string;
+  catchphrase?: string;
+};
+
+/** 桌宠浮层可展开的展示状态（UI 视图层）。 */
+export type PetDockView = {
+  /** 当前激活皮（缺失时由调用方回退内置默认皮） */
+  pet: PetDockPetView | null;
+  /** 浮层是否展开（收起时只留小图标） */
+  expanded: boolean;
+  /** 简化状态帧：闲时/运行中（UI 仅按会话状态提示） */
+  state: "idle" | "working";
+};
+
+export type PetDockLayoutPreferences = {
+  expanded: boolean;
+  /** 拖动后的位置（百分比 0-100，桌面浮层锚点） */
+  xPercent: number;
+  yPercent: number;
+};

--- a/packages/nextclaw-ui/src/features/pet/utils/pet-dock-view.utils.ts
+++ b/packages/nextclaw-ui/src/features/pet/utils/pet-dock-view.utils.ts
@@ -1,0 +1,21 @@
+import type { PetDockView } from '@/features/pet/types/pet-view.types';
+
+/** 默认皮视图数据（UI 展示层，纯 emoji 文字形象，无需位图/服务端）。 */
+export const DEFAULT_PET_VIEW: PetDockView = {
+  pet: {
+    id: 'mochi-claw',
+    name: '小爪',
+    description: '一只暖洋洋的爪爪桌宠，陪你查资料、写文件、整理表格。',
+    emoji: '🐾',
+    vibe: 'warm',
+    catchphrase: '爪爪到，事办妥。',
+  },
+  expanded: false,
+  state: 'idle',
+};
+
+/** 展示标签：当前皮名 + 状态提示。 */
+export function buildPetDockLabel(view: PetDockView): string {
+  const name = view.pet?.name ?? '桌宠';
+  return view.state === 'working' ? `${name} · 忙ing` : name;
+}


### PR DESCRIPTION
## 目标

按桌宠设计（docs/designs/2026-09-05-desktop-pet.design.md）PR-B 落地桌宠 UI 浮层组件。依赖同系列 PR-A（#45，core 皮契约）——本分支基于 codex/pet-a（含 #45 提交），经与用户确认以叠 PR 方式交付，PR-A 合入后本 PR diff 将自动收敛为纯 UI 增量。

## 改动（@nextclaw/ui，features/pet 新增 8 文件）

**PetDock（右下角可拖可收浮层）**
- 默认折叠为小图标（桌宠 emoji），点击展开气泡：名字 / 性格 / 口头禅
- 按住可拖动，百分比定位（2-96 / 4-92）持久化到 localStorage（zustand persist）
- 宿主可注入 `onGoToChat`（去对话）与 `onRequestNewPet`（AI 生成皮入口，未注入不渲染该按钮，避免 stub）

**PetSprite**
- 纯 emoji 文字形象，无位图依赖；working/idle 状态帧切换（简化）

**usePetDockStore**
- zustand persist 布局偏好；merge 抽为纯函数 `mergePetDockPersistedLayout`（越界/非法值回退默认，便于单测）

**导出**：feature 根 `index.ts` 注册组件/store/类型/视图工具

## 边界

- AI 生成皮链路与 server 读皮目录端点按设计归属后续 PR（PR-C/D）；本 PR 为纯 UI 组件层
- 未接宿主（桌面布局/会话），气泡动作由宿主注入回调驱动

## 验证

- pet 单测 11/11（store 6：merge 纯函数 3 + store 行为 3；组件 5：折叠/展开气泡/入口注入显隐）
- UI tsc：features/pet 0 errors（上游既有 17 个 apps 错误经干净基线 worktree 复现，与本 PR 无关）
- `pnpm lint:new-code:governance --base origin/master` all checks passed
