### PR TITLE
perf(ui): memoize provider form and model list to stop re-render storms

### DIFF
--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-form.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-form.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import {
   useConfigSchema,
   useDeleteProvider,
@@ -39,7 +39,7 @@ type ProviderFormEditorProps = {
   language: ReturnType<typeof getLanguage>;
 };
 
-export function ProviderForm({
+export const ProviderForm = memo(function ProviderForm({
   providerName,
   onProviderDeleted,
 }: ProviderFormProps) {
@@ -92,7 +92,7 @@ export function ProviderForm({
       language={language}
     />
   );
-}
+});
 
 function ProviderFormEditor({
   providerName,

--- a/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
+++ b/packages/nextclaw-ui/src/features/settings/components/config/provider-model-list.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { Settings2, Trash2, X } from "lucide-react";
 import type { ThinkingLevel } from "@/shared/lib/api";
 import { Label } from "@/shared/components/ui/label";
@@ -40,7 +40,7 @@ type ProviderModelListProps = {
   formatThinkingLevelLabel: (level: ThinkingLevel) => string;
 };
 
-export function ProviderModelList(props: ProviderModelListProps) {
+export const ProviderModelList = memo(function ProviderModelList(props: ProviderModelListProps) {
   const {
     models,
     modelConfig,
@@ -290,4 +290,4 @@ export function ProviderModelList(props: ProviderModelListProps) {
       ) : null}
     </div>
   );
-}
+});


### PR DESCRIPTION
Provider 表单与模型列表在设置页高频重渲染（语言切换、其它 state 变化时整表重建）。memo 化两个组件，props 未变时跳过重渲染。

## 验证
- tsc --noEmit 0 错、vite build 成功
- pnpm lint:new-code:governance --base origin/master all checks passed