### PR TITLE
fix(desktop): add manual Portable Edition download link

### DIFF
--- a/.changeset/portable-manual-update-download.md
+++ b/.changeset/portable-manual-update-download.md
@@ -1,0 +1,5 @@
+---
+"@nextclaw/ui": patch
+---
+
+Add a manual download link to the GitHub Releases page when Portable Edition cannot update in-app.

--- a/packages/nextclaw-ui/src/features/system-status/components/__tests__/desktop-update-config.test.tsx
+++ b/packages/nextclaw-ui/src/features/system-status/components/__tests__/desktop-update-config.test.tsx
@@ -181,6 +181,46 @@ describe('DesktopUpdateConfig', () => {
     expect(screen.getByText('fetch failed: getaddrinfo ENOTFOUND updates.nextclaw.io')).toBeTruthy();
   });
 
+  it('offers a manual Portable Edition download when in-app updates are blocked', () => {
+    useRuntimeUpdateStore.setState((state) => ({
+      ...state,
+      snapshot: state.snapshot
+        ? {
+            ...state.snapshot,
+            status: 'blocked',
+            installationKind: 'desktop-bundle',
+            blockReason: 'unsupported-installation',
+            errorMessage: 'Portable Edition does not support in-app updates yet. Download a newer Portable Edition and keep the data directory.'
+          }
+        : null
+    }));
+
+    renderDesktopUpdateConfig();
+
+    const downloadLink = screen.getByRole('link', { name: '下载最新 Portable Edition' });
+    expect(downloadLink.getAttribute('href')).toBe('https://github.com/Peiiii/nextclaw/releases');
+    expect(downloadLink.getAttribute('target')).toBe('_blank');
+  });
+
+  it('does not offer a Portable Edition download for non-desktop update blocks', () => {
+    useRuntimeUpdateStore.setState((state) => ({
+      ...state,
+      snapshot: state.snapshot
+        ? {
+            ...state.snapshot,
+            status: 'blocked',
+            installationKind: 'npm-runtime-bundle',
+            blockReason: 'unsupported-installation',
+            errorMessage: 'This runtime does not support updates.'
+          }
+        : null
+    }));
+
+    renderDesktopUpdateConfig();
+
+    expect(screen.queryByRole('link', { name: '下载最新 Portable Edition' })).toBeNull();
+  });
+
   it('loads structured release notes from the docs JSON endpoint', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       schemaVersion: 1,

--- a/packages/nextclaw-ui/src/features/system-status/components/desktop-update-config.tsx
+++ b/packages/nextclaw-ui/src/features/system-status/components/desktop-update-config.tsx
@@ -16,7 +16,9 @@ import {
   type ReleaseNotesLocale,
   type ReleaseNotesSection
 } from '@/features/system-status/utils/update-release-notes.utils';
-import { RefreshCw, RotateCw } from 'lucide-react';
+import { Download, RefreshCw, RotateCw } from 'lucide-react';
+
+const PORTABLE_RELEASES_URL = 'https://github.com/Peiiii/nextclaw/releases';
 
 const STATUS_LABEL_KEYS: Record<string, string> = {
   checking: 'desktopUpdatesStatusChecking',
@@ -115,6 +117,12 @@ function getStatusTone(status: string): string {
     return 'bg-red-50 text-red-700 ring-red-100';
   }
   return 'bg-gray-100 text-gray-700 ring-gray-200';
+}
+
+function isPortableUpdateBlocked(snapshot: UpdateSnapshot): boolean {
+  return snapshot.status === 'blocked'
+    && snapshot.installationKind === 'desktop-bundle'
+    && snapshot.blockReason === 'unsupported-installation';
 }
 
 function getReleaseNotesLocale(): ReleaseNotesLocale {
@@ -265,6 +273,16 @@ export function DesktopUpdateConfig() {
                 <p className='text-sm font-semibold text-red-800'>{t('desktopUpdatesBlockedTitle')}</p>
                 <p className='mt-1 text-sm text-red-700'>{snapshot.errorMessage ?? t('desktopUpdatesBlockedDescription')}</p>
                 {snapshot.recoveryCommand ? <code className='mt-3 block rounded-lg bg-white/70 px-3 py-2 text-xs text-red-800'>{snapshot.recoveryCommand}</code> : null}
+                {isPortableUpdateBlocked(snapshot) ? (
+                  <NavigationLink
+                    href={PORTABLE_RELEASES_URL}
+                    external
+                    icon={Download}
+                    className='mt-3 rounded-full border border-red-300 bg-white/70 px-3 py-2 text-red-800 no-underline hover:bg-white hover:text-red-900 hover:no-underline'
+                  >
+                    {t('desktopUpdatesManualPortableDownload')}
+                  </NavigationLink>
+                ) : null}
               </div>
             ) : null}
             {snapshot.errorMessage && snapshot.status !== 'blocked' ? <div className='rounded-2xl border border-red-200 bg-red-50/70 p-4 text-sm text-red-700'>{snapshot.errorMessage}</div> : null}

--- a/packages/nextclaw-ui/src/shared/lib/i18n/locales/en-US/desktop-update.json
+++ b/packages/nextclaw-ui/src/shared/lib/i18n/locales/en-US/desktop-update.json
@@ -63,6 +63,7 @@
   "desktopUpdatesDownloadProgressUnknown": "Downloading",
   "desktopUpdatesBlockedTitle": "Update Blocked",
   "desktopUpdatesBlockedDescription": "Resolve the current installation requirement before continuing the update.",
+  "desktopUpdatesManualPortableDownload": "Download Latest Portable Edition",
   "desktopUpdatesBlockedRootCause.signature-verification-unavailable": "Root cause: missing update public key; install a configured build or ask the maintainer to set the key.",
   "desktopUpdatesBlockedRootCause.host-too-old": "Root cause: the host is too old for this runtime bundle; upgrade the NextClaw launcher first.",
   "desktopUpdatesBlockedRootCause.unsupported-installation": "Root cause: this installation or update source does not support auto-update; use a configured build.",

--- a/packages/nextclaw-ui/src/shared/lib/i18n/locales/zh-CN/desktop-update.json
+++ b/packages/nextclaw-ui/src/shared/lib/i18n/locales/zh-CN/desktop-update.json
@@ -63,6 +63,7 @@
   "desktopUpdatesDownloadProgressUnknown": "正在下载",
   "desktopUpdatesBlockedTitle": "更新暂时无法继续",
   "desktopUpdatesBlockedDescription": "当前安装环境需要先处理阻塞项，之后才能继续更新。",
+  "desktopUpdatesManualPortableDownload": "下载最新 Portable Edition",
   "desktopUpdatesBlockedRootCause.signature-verification-unavailable": "根因：缺少更新签名公钥，无法验证更新包来源；请安装包含正确更新配置的新版本，或由维护者配置更新公钥。",
   "desktopUpdatesBlockedRootCause.host-too-old": "根因：当前宿主版本太旧，不满足新运行包的最低宿主版本要求；请先升级 NextClaw 启动器。",
   "desktopUpdatesBlockedRootCause.unsupported-installation": "根因：当前安装形态或更新源配置不支持自动更新；请安装支持自动更新的版本，或由维护者补齐更新源配置。",


### PR DESCRIPTION
## Summary

- Add a manual Portable Edition download link when in-app updates are blocked.
- Open the NextClaw GitHub Releases page through the existing external navigation path.
- Add English/Chinese labels, regression coverage, and a patch changeset.

## Verification

- `corepack pnpm --filter @nextclaw/ui exec vitest run src/features/system-status/components/__tests__/desktop-update-config.test.tsx` — 8 passed
- `corepack pnpm --filter @nextclaw/ui exec vitest run src/shared/components/actions/__tests__/navigation-link.test.tsx` — 3 passed
- Changed-file ESLint — passed
- `git diff --check` — passed

The full UI suite and package-wide TypeScript check still have unrelated existing baseline failures in this checkout.